### PR TITLE
Wider claimant modals + number of claimants

### DIFF
--- a/achievements/templates/achievements/achievement_block_card.html
+++ b/achievements/templates/achievements/achievement_block_card.html
@@ -49,7 +49,7 @@
 
 <!-- All claimants modal -->
 <div class="modal fade modal-achievement" id="modal_achievement_{{achievement.id}}" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">{{achievement.name}} Claimants</h5>

--- a/achievements/templates/achievements/achievement_block_user.html
+++ b/achievements/templates/achievements/achievement_block_user.html
@@ -48,7 +48,7 @@
 
 <!-- All claimants modal -->
 <div class="modal fade modal-achievement" id="modal_achievement_{{achievement.id}}" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
         <div class="modal-content">
         <div class="modal-header">
             <h5 class="modal-title">Your {{achievement.name}} Claim History</h5>

--- a/achievements/templates/achievements/achievement_block_wide.html
+++ b/achievements/templates/achievements/achievement_block_wide.html
@@ -41,7 +41,7 @@
                                 <small class="text-muted">
                                     {% if achievement.claimants|length > num_shown_claimants %}
                                         <a href="#" data-toggle="modal" data-target="#modal_achievement_{{achievement.id}}">
-                                            View All Claimants
+                                            View All {{ achievement.claimants|length }} Claimants
                                         </a>
                                     {% else %}
                                         {% if achievement.claimants|length > 0 %}
@@ -60,7 +60,7 @@
 
 <!-- All claimants modal -->
 <div class="modal fade modal-achievement" id="modal_achievement_{{achievement.id}}" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
         <div class="modal-content">
         <div class="modal-header">
             <h5 class="modal-title">{{achievement.name}} Claim History</h5>


### PR DESCRIPTION
The modal listing an achievement's claimants is now wider (matches the slot-creation modal width).

For logged in members, the number of total claimants is now shown on the 'show all claimants' button.