### PR TITLE
Add EditorConfig configuration file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{css,html,js,json,py}]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
+# end_of_line is handled by Git
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
This makes it easier to share settings between editors and can serve as
a baseline while we don't have a formatter for that filetype installed.