### PR TITLE
Fix/90 dst causes 404

### DIFF
--- a/activity_calendar/admin.py
+++ b/activity_calendar/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.utils.timezone import localtime
+
 from .models import Activity, ActivitySlot, Participant
 
 
@@ -22,7 +24,7 @@ class ParticipantInline(admin.TabularInline):
 class ActivitySlotAdmin(admin.ModelAdmin):
     def recurrence_id_with_day(self, obj):
         if obj.recurrence_id is not None:
-            return obj.recurrence_id.strftime("%a, %d %b %Y, %H:%M")
+            return localtime(obj.recurrence_id).strftime("%a, %d %b %Y, %H:%M")
         return None
     recurrence_id_with_day.admin_order_field = 'recurrence_id'
     recurrence_id_with_day.short_description = 'Activity Start Date'

--- a/activity_calendar/api.py
+++ b/activity_calendar/api.py
@@ -104,18 +104,12 @@ def fullcalendar_feed(request):
         # If the activity ends on a different day than it starts, this also needs to be the case for the occurrence
         time_diff = recurring_activity.end_date - recurring_activity.start_date
 
-        for occurence in recurrences.between(start_date, end_date, dtstart=recurring_activity.start_date, inc=True):
-            # recurrence does not handle daylight-saving time! If we were to keep the occurence as is,
-            # then summer events would occur an hour earlier in winter!
-            occurence = timezone.get_current_timezone().localize(
-                datetime.combine(timezone.localtime(occurence).date(), event_start_time)
-            )
-
+        # for occurence in recurrences.between(start_date, end_date, dtstart=recurring_activity.start_date, inc=True):
+        for occurence in recurring_activity.get_occurences_between(start_date, end_date, inc=True):
             activities.append(get_activity_json(
                 recurring_activity,
                 occurence,
                 (occurence + time_diff),
                 request.user
             ))
-
     return JsonResponse({'activities': activities})

--- a/activity_calendar/api.py
+++ b/activity_calendar/api.py
@@ -74,8 +74,14 @@ def fullcalendar_feed(request):
 
     # Obtain non-recurring activities
     activities = []
-    non_recurring_activities = Activity.objects.filter(recurrences="", published_date__lte=timezone.now()) \
-        .filter((Q(start_date__gte=start_date) | Q(end_date__lte=end_date)))
+    non_recurring_activities = (Activity.objects.filter(recurrences="", published_date__lte=timezone.now())
+            # Activity starts between the specified bounds
+        .filter((Q(start_date__gte=start_date, start_date__lte=end_date)
+            # Activity ends between the specified bounds
+            | Q(end_date__gte=start_date, end_date__lte=end_date)
+            # Activity takes place between the specified bounds, but doesn't start/end in it
+            | Q(start_date__lte=start_date, end_date__gte=end_date)))
+    )
 
     for non_recurring_activity in non_recurring_activities:
         activities.append(get_activity_json(

--- a/activity_calendar/api.py
+++ b/activity_calendar/api.py
@@ -110,7 +110,6 @@ def fullcalendar_feed(request):
         # If the activity ends on a different day than it starts, this also needs to be the case for the occurrence
         time_diff = recurring_activity.end_date - recurring_activity.start_date
 
-        # for occurence in recurrences.between(start_date, end_date, dtstart=recurring_activity.start_date, inc=True):
         for occurence in recurring_activity.get_occurences_between(start_date, end_date, inc=True):
             activities.append(get_activity_json(
                 recurring_activity,

--- a/activity_calendar/feeds.py
+++ b/activity_calendar/feeds.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 import django_ical.feedgenerator
 
-from django_ical.utils import build_rrule_from_recurrences_rrule, build_rrule_from_text
+from django_ical.utils import build_rrule_from_recurrences_rrule
 from django_ical.views import ICalFeed
 from django_ical.feedgenerator import ICal20Feed
 from icalendar.cal import Timezone, TimezoneStandard, TimezoneDaylight

--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -261,6 +261,15 @@ class Activity(models.Model):
     def has_occurence_at(self, date):
         if not self.is_recurring:
             return date == self.start_date
+        else:
+            start_utc_offset = timezone.localtime(self.start_date).utcoffset()
+            date_utc_offset = date.utcoffset()
+            
+            # the recurrences package does not work with DST. Since we want our activities
+            # to ignore DST (E.g. events starting at 16.00 is summer should still start at 16.00
+            # in winter), we have to account for the difference here.
+            date = date + (date_utc_offset - start_utc_offset)
+
         occurences = self.recurrences.between(date, date, dtstart=self.start_date, inc=True)
         return bool(occurences)
 

--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -5,11 +5,11 @@ from django.db.models import Count
 from django.utils import timezone, http
 from django.urls import reverse
 
-from membership_file.util import user_to_member
-
 from recurrence.fields import RecurrenceField
 
+from .util import dst_aware_to_dst_ignore
 from core.models import ExtendedUser as User, PresetImage
+from membership_file.util import user_to_member
 
 # Models related to the Calendar-functionality of the application.
 # @since 29 JUN 2019
@@ -258,20 +258,23 @@ class Activity(models.Model):
         return bool(self.recurrences.rdates or self.recurrences.rrules)
     
     # Whether this activity has an occurence at a specific date
-    def has_occurence_at(self, date):
+    def has_occurence_at(self, date, is_dst_aware=False):
         if not self.is_recurring:
             return date == self.start_date
-        else:
-            start_utc_offset = timezone.localtime(self.start_date).utcoffset()
-            date_utc_offset = date.utcoffset()
-            
-            # the recurrences package does not work with DST. Since we want our activities
-            # to ignore DST (E.g. events starting at 16.00 is summer should still start at 16.00
-            # in winter), we have to account for the difference here.
-            date = date + (date_utc_offset - start_utc_offset)
 
-        occurences = self.recurrences.between(date, date, dtstart=self.start_date, inc=True)
-        return bool(occurences)
+        if not is_dst_aware:
+            date = dst_aware_to_dst_ignore(date, self.start_date, reverse=True)
+        occurences = self.get_occurences_between(date, date, dtstart=self.start_date, inc=True)
+        return next(occurences, None) is not None
+
+    def get_occurences_between(self, after, before, inc=False, dtstart=None, dtend=None, cache=False):
+        dtstart = dtstart or self.start_date
+
+        # the recurrences package does not work with DST. Since we want our activities
+        # to ignore DST (E.g. events starting at 16.00 is summer should still start at 16.00
+        # in winter, and vice versa), we have to account for the difference here.
+        return map(lambda occurence: dst_aware_to_dst_ignore(occurence, dtstart), self.recurrences.between(after, before, inc=inc,
+                dtstart=dtstart, dtend=dtend, cache=cache))     
 
     def clean_fields(self, exclude=None):
         super().clean_fields(exclude=exclude)

--- a/activity_calendar/tests/tests_fullcalendar.py
+++ b/activity_calendar/tests/tests_fullcalendar.py
@@ -33,19 +33,21 @@ class TestCaseFullCalendar(TestCase):
         for activity in activities:
             if activity.get('groupId') == 9:
                 self.assertEqual(activity.get('title'), 'Weekly CEST Event')
-                self.assertEqual(activity.get('start'), '2020-10-24T12:00:00+02:00')
-                self.assertEqual(activity.get('end'), '2020-10-24T17:30:00+02:00')
+                self.assertEqual(activity.get('start'), '2020-10-24T10:00:00+00:00')
+                self.assertEqual(activity.get('end'), '2020-10-24T15:30:00+00:00')
             else:
                 self.assertEqual(activity.get('groupId'), 1)
                 self.assertEqual(activity.get('title'), 'Weekly activity')
 
                 # Check pre- and post- DST-switch dates
-                if not has_seen_pre_dst and activity.get('start') == '2020-10-20T19:30:00+02:00':
+                if not has_seen_pre_dst and activity.get('start') == '2020-10-20T17:30:00+00:00':
                     has_seen_pre_dst = True
-                    self.assertEqual(activity.get('end'), '2020-10-21T04:00:00+02:00')
-                elif not has_seen_post_dst and activity.get('start') == '2020-10-27T19:30:00+01:00':
+                    self.assertEqual(activity.get('end'), '2020-10-21T02:00:00+00:00')
+                elif not has_seen_post_dst and activity.get('start') == '2020-10-27T18:30:00+00:00':
+                    # Activity should start/end an hour 'later' as to account for DST-changes from
+                    # CEST (UTC+2) to CET (UTC+1)
                     has_seen_post_dst = True
-                    self.assertEqual(activity.get('end'), '2020-10-28T04:00:00+01:00')
+                    self.assertEqual(activity.get('end'), '2020-10-28T03:00:00+00:00')
                 else:
                     self.fail(f"Found a start-time that should not occur: <{activity.get('start')}>")
 
@@ -75,8 +77,8 @@ class TestCaseFullCalendar(TestCase):
         self.assertEqual(activity.get('location'), 'Online')
         self.assertEqual(activity.get('description'), 'Occurs every week, except once during daylight saving time (dst) and once during standard time!')
         self.assertEqual(activity.get('allDay'), False)
-        self.assertEqual(activity.get('start'), '2020-10-24T12:00:00+02:00')
-        self.assertEqual(activity.get('end'), '2020-10-24T17:30:00+02:00')
+        self.assertEqual(activity.get('start'), '2020-10-24T10:00:00+00:00')
+        self.assertEqual(activity.get('end'), '2020-10-24T15:30:00+00:00')
 
     @suppress_warnings
     def test_missing_start_or_end(self):

--- a/activity_calendar/tests/tests_model_helpers.py
+++ b/activity_calendar/tests/tests_model_helpers.py
@@ -1,11 +1,7 @@
 from django.test import TestCase
-from django.utils import timezone
-from unittest.mock import patch
 
 from activity_calendar.models import Activity, ActivitySlot, Participant
 from core.models import ExtendedUser as User
-
-from . import mock_now
 
 ##################################################################################
 # Test the Activity and related models' helper methods
@@ -15,23 +11,13 @@ from . import mock_now
 class ActivityRelatedModelHelpersTest(TestCase):
     fixtures = ['test_users.json']
 
-    def setUp(self):
-        activity_data = {
-            'id': 4,
-            'title': 'Wow',
-            # Start/end dates are during CET (UTC+1)
-            # Start dt: 01 JAN 2020, 15.00 (CET)
-            'start_date': timezone.datetime(2020, 1, 1, 14, 0, 0, tzinfo=timezone.utc),
-            'end_date': timezone.datetime(2020, 1, 1, 18, 0, 0, tzinfo=timezone.utc),
-            'recurrences': "RRULE:FREQ=WEEKLY;BYDAY=TU"
-        }
-        
-        self.activity = Activity(**activity_data)
+    def setUp(self):        
+        self.activity = Activity(id=4, title="Wow")
         self.slot = ActivitySlot(id=1, parent_activity=self.activity, title="Wow2")
 
     # Tests the display method of Activity
     def test_activity_display(self):
-        self.assertEqual(str(self.activity), "Wow (recurring)")
+        self.assertEqual(str(self.activity), "Wow (not recurring)")
 
     # Tests the display method of ActivitySlot
     def test_activityslot_display(self):
@@ -41,69 +27,3 @@ class ActivityRelatedModelHelpersTest(TestCase):
     def test_participant_display(self):
         participant = Participant(activity_slot=self.slot, user=User.objects.filter(username="test_user").first())
         self.assertEqual(str(participant), participant.user.get_simple_display_name())
-
-    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 3, 20, 0, 0)))
-    def test_has_occurence_at_same_dst(self, mock_tz):
-        pass
-
-    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 3, 20, 0, 0)))
-    def test_CET_has_occurence_at_CET_to_CEST(self, mock_tz):
-        """
-            Query an activity ocurrence when
-            - that activity's first occurence was in CET
-            - our current timezone is in CET
-            - the queried occurence is in CEST
-        """
-        query_dt = timezone.make_aware(timezone.datetime(2020, 3, 31, 15, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
-
-        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
-        self.assertTrue(has_occurence_at_query_dt)
-
-    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 3, 20, 0, 0)))
-    def test_CET_has_occurence_at_CEST_to_CET(self, mock_tz):
-        """
-            Query an activity ocurrence when
-            - that activity's first occurence was in CEST
-            - our current timezone is in CET
-            - the queried occurence is in CET
-        """
-        # Make start/end date in CEST (UTC+2)
-        # Start dt: 01 MAR 2020, 16.00 (CEST)
-        self.activity.start_date = timezone.datetime(2020, 6, 1, 14, 0, 0, tzinfo=timezone.utc)
-        self.activity.end_date = timezone.datetime(2020, 6, 1, 18, 0, 0, tzinfo=timezone.utc)
-
-        query_dt = timezone.make_aware(timezone.datetime(2020, 10, 27, 16, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
-
-        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
-        self.assertTrue(has_occurence_at_query_dt)
-
-    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 10, 20, 0, 0)))
-    def test_CEST_has_occurence_at_CET_to_CEST(self, mock_tz):
-        """
-            Query an activity ocurrence when
-            - that activity's first occurence was in CET
-            - our current timezone is in CEST
-            - the queried occurence is in CEST
-        """
-        query_dt = timezone.make_aware(timezone.datetime(2020, 3, 31, 15, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
-
-        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
-        self.assertTrue(has_occurence_at_query_dt)
-
-    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 10, 20, 0, 0)))
-    def test_CEST_has_occurence_at_CEST_to_CET(self, mock_tz):
-        """
-            Query an activity ocurrence when
-            - that activity's first occurence was in CEST
-            - our current timezone is in CET
-            - the queried occurence is in CET
-        """
-        # Make start/end date in CEST (UTC+2)
-        # Start dt: 01 MAR 2020, 16.00 (CEST)
-        self.activity.start_date = timezone.datetime(2020, 6, 1, 14, 0, 0, tzinfo=timezone.utc)
-        self.activity.end_date = timezone.datetime(2020, 6, 1, 18, 0, 0, tzinfo=timezone.utc)
-
-        query_dt = timezone.make_aware(timezone.datetime(2020, 10, 27, 16, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
-
-        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
-        self.assertTrue(has_occurence_at_query_dt)

--- a/activity_calendar/tests/tests_model_helpers.py
+++ b/activity_calendar/tests/tests_model_helpers.py
@@ -55,8 +55,6 @@ class ActivityRelatedModelHelpersTest(TestCase):
             - the queried occurence is in CEST
         """
         query_dt = timezone.make_aware(timezone.datetime(2020, 3, 31, 15, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
-        print(f"Query dt: {query_dt}")
-        print(f"Start dt: {timezone.localtime(self.activity.start_date)}")
 
         has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
         self.assertTrue(has_occurence_at_query_dt)

--- a/activity_calendar/tests/tests_model_helpers.py
+++ b/activity_calendar/tests/tests_model_helpers.py
@@ -11,7 +11,7 @@ from core.models import ExtendedUser as User
 class ActivityRelatedModelHelpersTest(TestCase):
     fixtures = ['test_users.json']
 
-    def setUp(self):        
+    def setUp(self):
         self.activity = Activity(id=4, title="Wow")
         self.slot = ActivitySlot(id=1, parent_activity=self.activity, title="Wow2")
 

--- a/activity_calendar/tests/tests_model_helpers.py
+++ b/activity_calendar/tests/tests_model_helpers.py
@@ -1,7 +1,11 @@
 from django.test import TestCase
+from django.utils import timezone
+from unittest.mock import patch
 
 from activity_calendar.models import Activity, ActivitySlot, Participant
 from core.models import ExtendedUser as User
+
+from . import mock_now
 
 ##################################################################################
 # Test the Activity and related models' helper methods
@@ -12,12 +16,22 @@ class ActivityRelatedModelHelpersTest(TestCase):
     fixtures = ['test_users.json']
 
     def setUp(self):
-        self.activity = Activity(id=4, title="Wow")
+        activity_data = {
+            'id': 4,
+            'title': 'Wow',
+            # Start/end dates are during CET (UTC+1)
+            # Start dt: 01 JAN 2020, 15.00 (CET)
+            'start_date': timezone.datetime(2020, 1, 1, 14, 0, 0, tzinfo=timezone.utc),
+            'end_date': timezone.datetime(2020, 1, 1, 18, 0, 0, tzinfo=timezone.utc),
+            'recurrences': "RRULE:FREQ=WEEKLY;BYDAY=TU"
+        }
+        
+        self.activity = Activity(**activity_data)
         self.slot = ActivitySlot(id=1, parent_activity=self.activity, title="Wow2")
 
     # Tests the display method of Activity
     def test_activity_display(self):
-        self.assertEqual(str(self.activity), "Wow (not recurring)")
+        self.assertEqual(str(self.activity), "Wow (recurring)")
 
     # Tests the display method of ActivitySlot
     def test_activityslot_display(self):
@@ -27,3 +41,71 @@ class ActivityRelatedModelHelpersTest(TestCase):
     def test_participant_display(self):
         participant = Participant(activity_slot=self.slot, user=User.objects.filter(username="test_user").first())
         self.assertEqual(str(participant), participant.user.get_simple_display_name())
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 3, 20, 0, 0)))
+    def test_has_occurence_at_same_dst(self, mock_tz):
+        pass
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 3, 20, 0, 0)))
+    def test_CET_has_occurence_at_CET_to_CEST(self, mock_tz):
+        """
+            Query an activity ocurrence when
+            - that activity's first occurence was in CET
+            - our current timezone is in CET
+            - the queried occurence is in CEST
+        """
+        query_dt = timezone.make_aware(timezone.datetime(2020, 3, 31, 15, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        print(f"Query dt: {query_dt}")
+        print(f"Start dt: {timezone.localtime(self.activity.start_date)}")
+
+        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
+        self.assertTrue(has_occurence_at_query_dt)
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 3, 20, 0, 0)))
+    def test_CET_has_occurence_at_CEST_to_CET(self, mock_tz):
+        """
+            Query an activity ocurrence when
+            - that activity's first occurence was in CEST
+            - our current timezone is in CET
+            - the queried occurence is in CET
+        """
+        # Make start/end date in CEST (UTC+2)
+        # Start dt: 01 MAR 2020, 16.00 (CEST)
+        self.activity.start_date = timezone.datetime(2020, 6, 1, 14, 0, 0, tzinfo=timezone.utc)
+        self.activity.end_date = timezone.datetime(2020, 6, 1, 18, 0, 0, tzinfo=timezone.utc)
+
+        query_dt = timezone.make_aware(timezone.datetime(2020, 10, 27, 16, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+
+        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
+        self.assertTrue(has_occurence_at_query_dt)
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 10, 20, 0, 0)))
+    def test_CEST_has_occurence_at_CET_to_CEST(self, mock_tz):
+        """
+            Query an activity ocurrence when
+            - that activity's first occurence was in CET
+            - our current timezone is in CEST
+            - the queried occurence is in CEST
+        """
+        query_dt = timezone.make_aware(timezone.datetime(2020, 3, 31, 15, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+
+        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
+        self.assertTrue(has_occurence_at_query_dt)
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 10, 20, 0, 0)))
+    def test_CEST_has_occurence_at_CEST_to_CET(self, mock_tz):
+        """
+            Query an activity ocurrence when
+            - that activity's first occurence was in CEST
+            - our current timezone is in CET
+            - the queried occurence is in CET
+        """
+        # Make start/end date in CEST (UTC+2)
+        # Start dt: 01 MAR 2020, 16.00 (CEST)
+        self.activity.start_date = timezone.datetime(2020, 6, 1, 14, 0, 0, tzinfo=timezone.utc)
+        self.activity.end_date = timezone.datetime(2020, 6, 1, 18, 0, 0, tzinfo=timezone.utc)
+
+        query_dt = timezone.make_aware(timezone.datetime(2020, 10, 27, 16, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+
+        has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
+        self.assertTrue(has_occurence_at_query_dt)

--- a/activity_calendar/url_converters.py
+++ b/activity_calendar/url_converters.py
@@ -19,4 +19,3 @@ class DateTimeIsoConverter:
     def to_url(self, datetime):
         assert datetime is datetime
         return quote(datetime.isoformat())
-        

--- a/activity_calendar/url_converters.py
+++ b/activity_calendar/url_converters.py
@@ -19,5 +19,4 @@ class DateTimeIsoConverter:
     def to_url(self, datetime):
         assert datetime is datetime
         return quote(datetime.isoformat())
-
-# item.start_date.astimezone(timezone.get_current_timezone())
+        

--- a/activity_calendar/util.py
+++ b/activity_calendar/util.py
@@ -1,7 +1,33 @@
-from django.utils.timezone import pytz
-from django.utils.timezone import now
+from django.utils.timezone import pytz, now, localtime
 import icalendar
 import datetime
+
+def dst_aware_to_dst_ignore(date, origin_date, reverse=False):
+    """
+        Takes the difference in UTC-offsets for two given dates, and applies that
+        difference to the first date. A reverse keyword indicates which direction
+        the offset should be shifted.
+        
+        Can be used to account keep times similar as if Daylight Saving Time did not exist.
+        E.g. If a date at 16.00h in CEST (UTC+2) should be considered to be the same time
+        as an origin date at 16.00h in CET (UTC+1), even though their UTC-times do not match.
+
+        :param date: The date to modify
+        :param origin_date: The origin date
+        :param reverse: If True,  shifts `date` backwards (i.e. `date` already acted as if it had
+                            the UTC-offset of `origin_date`, and we wish to reverse this change.)
+                        Otherwise, shifts `date` forward (i.e. makes the `date` act as if it had
+                            the UTC-offset of `origin_date`)
+    """
+
+    start_utc_offset = localtime(origin_date).utcoffset()
+    date_utc_offset = localtime(date).utcoffset()
+    
+    if reverse:
+        date = date - (start_utc_offset - date_utc_offset)
+    else:
+        date = date + (start_utc_offset - date_utc_offset)
+    return date
 
 # Based on: https://djangosnippets.org/snippets/10569/
 def generate_vtimezone(timezone, for_date=None, num_years=None):


### PR DESCRIPTION
Changes in Daylight Saving Time (DST) were not handled appropriately across the entire application.
This fix moves this special handling to fewer places in total, and introduces methods (E.g. getting activity occurrences between certain dates) that account for DST changes by using the special handling.
This should, to a certain extent, prevent usage of library methods that do not account for DST.

recurrence_id on the activity slot overview page is now correctly localised (right now, occurrences look like they take place 1 hour earlier in winter time for summer time activities). This was only the case in the admin panel; occurrences did show up correctly in the frontend.

The fullcalendar json also no longer returns (almost) all non-recurring events for every possible timeframe.

Closes #90 