### PR TITLE
Tweak the calendar

### DIFF
--- a/activity_calendar/static/js/fullcalendar-init.js
+++ b/activity_calendar/static/js/fullcalendar-init.js
@@ -5,12 +5,13 @@ document.addEventListener('DOMContentLoaded', function() {
         locale: 'en-gb', // We want dd/mm/yyy formatting
         firstDay: 1, // Weeks start on monday
         nowIndicator: true,
+        allDaySlot: false, // We don't have All Day slots at the moment, disable this bar
         eventTimeFormat: {
             hour: '2-digit',
             minute: '2-digit',
             meridiem: false, // AM/PM display
         },
-        initialView: $(window).width() < 992 ? 'listWeek' : 'timeGridWeek',
+        initialView: $(window).width() < 992 ? 'listWeek' : 'dayGridMonth',
         headerToolbar: {
             left: 'prev,next today',
             center: 'title',
@@ -18,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function() {
         },
         // Determines how far forward the scroll pane is initially scrolled.
         // This value ensures that evening-activities are visible without needing to scroll
-        scrollTime: '19:00:00',
+        scrollTime: '14:30:00',
         // customize the button names,
         // otherwise they'd all just say "list"
         views: {


### PR DESCRIPTION
- Turn off the All Day bar: we don't use it at the moment so we just hide it to get a few extra pixels
- Make the Month view the default calendar: we only organize a few events a day so this should give a better overview of the activities we organize
- Move the default scrollTime up to also show afternoon activities. This still shows the evening activities on a 1280x520 screen (720p with 200 horizontal pixels removed for a  browser bar)

This should stop activities hiding from view in the default calender view by changing the default view to one where they cannot hide and when people switch back to this week view they shouldn't miss these activities because the default scroll time moved up and because there is now more space because an useless bar was removed

Closes #103 