### PR TITLE
Fix/rdate and exdate sometimes fail

### DIFF
--- a/activity_calendar/feeds.py
+++ b/activity_calendar/feeds.py
@@ -180,13 +180,13 @@ class CESTEventFeed(ICalFeed):
     @only_for(Activity)
     def item_rdate(self, item):
         if item.recurrences:
-            return list(util.set_time_for_dates(item.recurrences.rdates, item.start_date))
+            return list(util.set_time_for_RDATE_EXDATE(item.recurrences.rdates, item.start_date))
 
     # Dates to exclude for recurrence rules
     @only_for(Activity)
     def item_exdate(self, item):
         if item.recurrences:
-            return list(util.set_time_for_dates(item.recurrences.exdates, item.start_date))
+            return list(util.set_time_for_RDATE_EXDATE(item.recurrences.exdates, item.start_date))
 
     # RECURRENCE-ID
     @only_for(ActivityMoment)

--- a/activity_calendar/feeds.py
+++ b/activity_calendar/feeds.py
@@ -10,7 +10,7 @@ from django_ical.views import ICalFeed
 from django_ical.feedgenerator import ICal20Feed
 
 from .models import Activity, ActivityMoment
-from .util import generate_vtimezone
+import activity_calendar.util as util
 
 # Monkey-patch; Why is this not open for extension in the first place?
 django_ical.feedgenerator.ITEM_EVENT_FIELD_MAP = (
@@ -80,7 +80,7 @@ class CESTEventFeed(ICalFeed):
     #######################################################
     # Timezone information (Daylight-saving time, etc.)
     def vtimezone(self):
-        tz_info = generate_vtimezone(settings.TIME_ZONE, datetime(2020, 1, 1))
+        tz_info = util.generate_vtimezone(settings.TIME_ZONE, datetime(2020, 1, 1))
         tz_info.add('x-lic-location', settings.TIME_ZONE)
         return tz_info
 
@@ -180,24 +180,13 @@ class CESTEventFeed(ICalFeed):
     @only_for(Activity)
     def item_rdate(self, item):
         if item.recurrences:
-            return item.recurrences.rdates
+            return list(util.set_time_for_dates(item.recurrences.rdates, item.start_date))
 
     # Dates to exclude for recurrence rules
     @only_for(Activity)
     def item_exdate(self, item):
         if item.recurrences:
-            # Each EXDATE's time needs to match the event start-time, but they default to midnigth in the widget!
-            # Since there's no possibility to select the time in the UI either, we're overriding it here
-            # and enforce each EXDATE's time to be equal to the event's start time
-            event_start_time = item.start_date.astimezone(timezone.get_current_timezone()).time()
-            item.recurrences.exdates = list(map(lambda dt:
-                    timezone.get_current_timezone().localize(
-                        datetime.combine(timezone.localtime(dt).date(),
-                        event_start_time)
-                    ),
-                    item.recurrences.exdates
-            ))
-            return item.recurrences.exdates
+            return list(util.set_time_for_dates(item.recurrences.exdates, item.start_date))
 
     # RECURRENCE-ID
     @only_for(ActivityMoment)

--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -171,8 +171,8 @@ class Activity(models.Model):
         # Since there is no possibility to select the RDATE/EXDATE time in the UI either, we need to
         #   override their time here so that it matches the event's start time. Their timezones are
         #   also changed into that of the event's start date
-        self.recurrences.exdates = list(util.set_time_for_dates(self.recurrences.exdates, dtstart))
-        self.recurrences.rdates = list(util.set_time_for_dates(self.recurrences.rdates, dtstart))
+        self.recurrences.exdates = list(util.set_time_for_RDATE_EXDATE(self.recurrences.exdates, dtstart))
+        self.recurrences.rdates = list(util.set_time_for_RDATE_EXDATE(self.recurrences.rdates, dtstart))
 
         # Get all occurences according to the recurrence module
         occurences = self.recurrences.between(after, before, inc=inc, dtstart=dtstart, dtend=dtend, cache=cache)

--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -213,6 +213,14 @@ class Activity(models.Model):
             if not r.rrules and (r.exrules or r.exdates):
                 recurrence_errors.append('Cannot exclude dates if the activity is non-recurring')
 
+            # At most one RRULE (RFC 5545)
+            if len(r.rrules) > 1:
+                recurrence_errors.append(f'Can add at most one recurrence rule, but got {len(r.rrules)} (Can still add multiple Recurring Dates)')
+
+            # EXRULEs (RFC 2445) are deprecated (per RFC 5545)
+            if len(r.exrules) > 0:
+                recurrence_errors.append(f'Exclusion Rules are unsupported (Exclusion Dates can still be used)')
+
             if recurrence_errors:
                 errors.update({'recurrences': recurrence_errors})
 

--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 
 from recurrence.fields import RecurrenceField
 
-from .util import dst_aware_to_dst_ignore
+import activity_calendar.util as util
 from core.models import ExtendedUser as User, PresetImage
 from membership_file.util import user_to_member
 
@@ -159,31 +159,28 @@ class Activity(models.Model):
             return date == self.start_date
 
         if not is_dst_aware:
-            date = dst_aware_to_dst_ignore(date, self.start_date, reverse=True)
+            date = util.dst_aware_to_dst_ignore(date, self.start_date, reverse=True)
         occurences = self.get_occurences_between(date, date, dtstart=self.start_date, inc=True)
         return occurences
 
     def get_occurences_between(self, after, before, inc=False, dtstart=None, dtend=None, cache=False):
         dtstart = dtstart or self.start_date
 
-        # recurrence expects each EXDATE's time to match the event's start time (in UTC; ignores DST)
-        # Why it doesn't store it that way in the first place remains a mystery
-        self.recurrences.exdates = list(map(
-            lambda exclude_date:
-                datetime.datetime.combine(
-                    timezone.localtime(exclude_date).date(),
-                    dtstart.time(),
-                    tzinfo=timezone.utc,
-                ),
-            self.recurrences.exdates
-        ))
+        # EXDATEs and RDATEs should match the event's start time, but in the recurrence-widget they
+        #   occur at midnight!
+        # Since there is no possibility to select the RDATE/EXDATE time in the UI either, we need to
+        #   override their time here so that it matches the event's start time. Their timezones are
+        #   also changed into that of the event's start date
+        self.recurrences.exdates = list(util.set_time_for_dates(self.recurrences.exdates, dtstart))
+        self.recurrences.rdates = list(util.set_time_for_dates(self.recurrences.rdates, dtstart))
 
         # Get all occurences according to the recurrence module
         occurences = self.recurrences.between(after, before, inc=inc, dtstart=dtstart, dtend=dtend, cache=cache)
+
         # the recurrences package does not work with DST. Since we want our activities
-        # to ignore DST (E.g. events starting at 16.00 is summer should still start at 16.00
-        # in winter, and vice versa), we have to account for the difference here.
-        occurences = list(map(lambda occurence: dst_aware_to_dst_ignore(occurence, dtstart), occurences))
+        #   to ignore DST (E.g. events starting at 16.00 is summer should still start at 16.00
+        #   in winter, and vice versa), we have to account for the difference here.
+        occurences = list(map(lambda occurence: util.dst_aware_to_dst_ignore(occurence, dtstart), occurences))
 
         return occurences
 

--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -171,8 +171,8 @@ class Activity(models.Model):
         # Since there is no possibility to select the RDATE/EXDATE time in the UI either, we need to
         #   override their time here so that it matches the event's start time. Their timezones are
         #   also changed into that of the event's start date
-        self.recurrences.exdates = list(util.set_time_for_RDATE_EXDATE(self.recurrences.exdates, dtstart))
-        self.recurrences.rdates = list(util.set_time_for_RDATE_EXDATE(self.recurrences.rdates, dtstart))
+        self.recurrences.exdates = list(util.set_time_for_RDATE_EXDATE(self.recurrences.exdates, dtstart, make_dst_ignore=True))
+        self.recurrences.rdates = list(util.set_time_for_RDATE_EXDATE(self.recurrences.rdates, dtstart, make_dst_ignore=True))
 
         # Get all occurences according to the recurrence module
         occurences = self.recurrences.between(after, before, inc=inc, dtstart=dtstart, dtend=dtend, cache=cache)

--- a/activity_calendar/tests/test_models.py
+++ b/activity_calendar/tests/test_models.py
@@ -289,16 +289,26 @@ class TestCaseActivityClean(TestCase):
         with self.assertRaises(ValidationError) as error:
             self.base_activity.clean_fields()
 
-    # Must do nothing if everything is defined correctly
+    # EXRULEs are no longer supported
+    def test_clean_deprecated_EXRULE(self):
+        self.base_activity.recurrences = deserialize_recurrence_test("EXRULE:FREQ=WEEKLY;BYDAY=TU")
+
+        with self.assertRaises(ValidationError) as error:
+            self.base_activity.clean_fields()
+
+    # Multiple RRULES are not supported
+    def test_clean_multiple_RRULEs(self):
+        self.base_activity.recurrences = deserialize_recurrence_test("RRULE:FREQ=WEEKLY;BYDAY=TU\nRRULE:FREQ=WEEKLY;BYDAY=MO")
+
+        with self.assertRaises(ValidationError) as error:
+            self.base_activity.clean_fields()
+
+    # Must not throw validation errors if everything is defined correctly
     def test_clean_correct(self):
         self.base_activity.clean_fields()
 
         self.base_activity.recurrences = deserialize_recurrence_test("RDATE:19700101T230000Z")
         self.base_activity.clean_fields()
-
-    def test_time_shift_in_get_occurences(self):
-        # Todo: Write test cases for Activity.get_occurences_between() method
-        pass
 
 
 class ActivityTestCase(TestCase):

--- a/activity_calendar/tests/test_models.py
+++ b/activity_calendar/tests/test_models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.contrib.auth.models import AnonymousUser
 from django.core.validators import ValidationError
 from django.conf import settings
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.utils import timezone
 
 from unittest.mock import patch
@@ -20,14 +20,7 @@ class ModelMethodsTest(TestCase):
     fixtures = ['test_users.json', 'test_activity_methods']
 
     def setUp(self):
-        self.client = Client()
-        self.user = User.objects.filter(username='test_user').first()
-        self.client.force_login(self.user)
-
         self.activity = Activity.objects.get(id=2)
-        self.simple_activity = Activity.objects.get(id=1)
-
-        self.upcoming_occurence_date = datetime.fromisoformat('2020-08-19T14:00:00').replace(tzinfo=timezone.utc)
 
     # Should provide the correct url if the activity has an image, or the default image if no image is given
     def test_image_url(self):
@@ -35,7 +28,6 @@ class ModelMethodsTest(TestCase):
 
         self.activity.image = None
         self.assertEqual(self.activity.image_url, f"{settings.STATIC_URL}images/activity_default.png")
-
 
 class ModelMethodsDSTDependentTests(TestCase):
     """
@@ -128,6 +120,141 @@ class ModelMethodsDSTDependentTests(TestCase):
 
         has_occurence_at_query_dt = self.activity.has_occurence_at(query_dt)
         self.assertTrue(has_occurence_at_query_dt)
+
+class EXDATEandRDATEwithDSTTests(TestCase):
+    """
+        Tests RDATEs and EXDATEs in combination with Daylight Saving Time
+    """
+
+    def setUp(self):
+        self.recurrence_iso = "RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TU"
+
+        activity_data = {
+            'id': 4,
+            'title': 'DST Test Event 2: Electric Boogaloo',
+            # Start/end dates are during CET (UTC+1)
+            # Start dt: 03 NOV 2020, 19.00 (CET)
+            'start_date': timezone.datetime(2020, 11, 3, 18, 0, 0, tzinfo=timezone.utc),
+            'end_date': timezone.datetime(2020, 11, 3, 23, 30, 0, tzinfo=timezone.utc),
+            'recurrences': self.recurrence_iso
+        }
+        self.activity = Activity(**activity_data)
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 12, 3, 0, 0)))
+    def test_RDATE_EXDATE_at_same_dst(self, mock_tz):
+        """
+            Query RDATEs and EXDATEs when:
+            - the activity's first occurence was in CET
+            - our current timezone is in CET
+            - RDATE/EXDATE are in CET
+
+            RDATEs: Wednesday 30 December 2020
+            EXDATEs: Tuesday 29 December 2020, Tuesday 12 January 2020
+        """
+        self.recurrence_iso += "\n\nRDATE:20201229T230000Z"
+        self.recurrence_iso += "\nEXDATE:20201228T230000Z\nEXDATE:20210111T230000Z"
+        self.activity.recurrences = deserialize_recurrence_test(self.recurrence_iso)
+
+        # 30 December RDATE
+        rdate_dt = timezone.make_aware(timezone.datetime(2020, 12, 30, 19, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        self.assertTrue(self.activity.has_occurence_at(rdate_dt))
+
+        # 29 December EXDATE
+        exdate_dt = timezone.make_aware(timezone.datetime(2020, 12, 29, 19, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        self.assertFalse(self.activity.has_occurence_at(exdate_dt))
+
+        # 12 January EXDATE
+        exdate_dt = timezone.make_aware(timezone.datetime(2021, 1, 12, 19, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        self.assertFalse(self.activity.has_occurence_at(exdate_dt))
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 12, 3, 0, 0)))
+    def test_CET_RDATE_EXDATE_CET_to_CEST(self, mock_tz):
+        """
+            Query RDATEs and EXDATEs when:
+            - the activity's first occurence was in CET
+            - our current timezone is in CET
+            - RDATE/EXDATE are in CEST
+        """
+        self._test_RDATE_EXDATE_CET_to_CEST()
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2021, 5, 1, 0, 0)))
+    def test_CEST_RDATE_EXDATE_CET_to_CEST(self, mock_tz):
+        """
+            Query RDATEs and EXDATEs when:
+            - the activity's first occurence was in CET
+            - our current timezone is in CEST
+            - RDATE/EXDATE are in CEST
+        """
+        self._test_RDATE_EXDATE_CET_to_CEST()
+
+    def _test_RDATE_EXDATE_CET_to_CEST(self):
+        """
+            Query RDATEs and EXDATEs when:
+            - the activity's first occurence was in CET
+            - RDATE/EXDATE are in CEST
+
+            The current timezone is set in a calling function
+
+            RDATEs: Monday 17 April 2021
+            EXDATE: Tuesday 4 April 2021
+        """
+        self.recurrence_iso += "\n\nRDATE:20210416T220000Z"
+        self.recurrence_iso += "\nEXDATE:20210403T220000Z"
+        self.activity.recurrences = deserialize_recurrence_test(self.recurrence_iso)
+
+        # 17 April RDATE
+        rdate_dt = timezone.make_aware(timezone.datetime(2021, 4, 17, 19, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        self.assertTrue(self.activity.has_occurence_at(rdate_dt))
+
+        # 04 April EXDATE
+        exdate_dt = timezone.make_aware(timezone.datetime(2021, 4, 4, 19, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        self.assertFalse(self.activity.has_occurence_at(exdate_dt))
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2020, 12, 3, 0, 0)))
+    def test_CET_RDATE_EXDATE_CEST_to_CET(self, mock_tz):
+        """
+            Query RDATEs and EXDATEs when:
+            - the activity's first occurence was in CEST
+            - our current timezone is in CET
+            - RDATE/EXDATE are in CET
+        """
+        self._test_RDATE_EXDATE_CEST_to_CET()
+
+    @patch('django.utils.timezone.now', side_effect=mock_now(timezone.datetime(2021, 5, 1, 0, 0)))
+    def test_CEST_RDATE_EXDATE_CEST_to_CET(self, mock_tz):
+        """
+            Query RDATEs and EXDATEs when:
+            - the activity's first occurence was in CEST
+            - our current timezone is in CET
+            - RDATE/EXDATE are in CET
+        """
+        self._test_RDATE_EXDATE_CEST_to_CET()
+
+    def _test_RDATE_EXDATE_CEST_to_CET(self):
+        """
+            Query RDATEs and EXDATEs when:
+            - the activity's first occurence was in CEST
+            - RDATE/EXDATE are in CET
+
+            The current timezone is set in a calling function
+
+            RDATEs: Thursday 22 October 2020
+            EXDATE: Tuesday 27 October 2020
+        """
+        # Start dt: 20 OCT 2020, 19.00 (CEST; UTC+2)
+        self.activity.start_date = timezone.datetime(2020, 10, 20, 17, 0, 0, tzinfo=timezone.utc)
+
+        self.recurrence_iso += "\n\nRDATE:20201021T230000Z"
+        self.recurrence_iso += "\nEXDATE:20201026T230000Z"
+        self.activity.recurrences = deserialize_recurrence_test(self.recurrence_iso)
+
+        # 22 October RDATE
+        rdate_dt = timezone.make_aware(timezone.datetime(2020, 10, 22, 19, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        self.assertTrue(self.activity.has_occurence_at(rdate_dt))
+
+        # 27 October EXDATE
+        exdate_dt = timezone.make_aware(timezone.datetime(2020, 10, 27, 19, 0, 0), timezone.pytz.timezone("Europe/Amsterdam"))
+        self.assertFalse(self.activity.has_occurence_at(exdate_dt))
 
 
 class TestCaseActivityClean(TestCase):

--- a/activity_calendar/tests/tests_icalendar.py
+++ b/activity_calendar/tests/tests_icalendar.py
@@ -55,9 +55,9 @@ class TestCaseICalendarExport(TestCase):
         self.assertEquals(vevent["DTEND"].to_ical(), b"20200816T173000")
         self.assertEquals(vevent["DTEND"].params["TZID"], "Europe/Amsterdam")
 
-        # EXDATEs converted to 'local' time.
-        # NB: Their start times must match the start time of the event, regardless of
-        # daylight saving time!
+        # EXDATEs converted to local time.
+        # NB: Their start times must match the start time of the event, as dst
+        #   is automatically accounted for by calendar software
         self.assertEquals(vevent["EXDATE"].to_ical(), b"20201017T120000,20201114T120000")
         self.assertEquals(vevent["EXDATE"].params["TZID"], "Europe/Amsterdam")
 
@@ -92,4 +92,3 @@ class TestCaseICalendarExport(TestCase):
                 self.assertEqual(sub["TZOFFSETTO"].to_ical(), "+0100")
             else:
                 self.fail(f"Only STANDARD or DAYLIGHT components must appear in VTIMEZONE. Got <{str(type(sub))}> instead!")
-        

--- a/activity_calendar/util.py
+++ b/activity_calendar/util.py
@@ -30,20 +30,29 @@ def dst_aware_to_dst_ignore(date, origin_date, reverse=False):
     return date
 
 
-def set_time_for_dates(dates, time):
+def set_time_for_RDATE_EXDATE(dates, time):
     """
         Sets the time (with the corresponding timezone) for a given set of dates.
+
+        Note: These dates (RDATEs or EXDATEs) are already DST-aware, but later down the
+            road (after obtaining the resulting occurences) all occurences are made DST-aware.
+            This would mean these dates are made DST-aware twice, so we prevent that by making
+            these dates dst-ignore.
 
         :param dates: Collection of datetime objects of which the time should be set
         :param time: A datetime object whose date and timezone are set to the collection of dates
     """
     local_time = time.astimezone(get_current_timezone()).time()
     return map(lambda date:
-        get_current_timezone().localize(
-            datetime.datetime.combine(localtime(date).date(), local_time)
+        dst_aware_to_dst_ignore(
+            get_current_timezone().localize(
+                datetime.datetime.combine(localtime(date).date(), local_time),
+            ),
+            time, reverse=True
         ),
         dates
     )
+
 
 # Based on: https://djangosnippets.org/snippets/10569/
 def generate_vtimezone(timezone, for_date=None, num_years=None):


### PR DESCRIPTION
- RDATEs are no longer off by one day when an activity occurs across a DST-switch.
- RDATEs show up at the appropriate time in external calendars, rather than at midnight (e.g. Google Calendar, Thunderbird, etc.)
- At most one RRULE can be included in each activity (RFC 5545)
- EXRULEs have been deprecated (RFC 5545)

Closes #106