### PR TITLE
Fixed privacy issue for boardgame owners

### DIFF
--- a/inventory/templates/inventory/front_design/boardgames_overview.html
+++ b/inventory/templates/inventory/front_design/boardgames_overview.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load paginator %}
 {% load inventory_tags %}
+{% load to_member %}
 
 {% block title %}
     Squire - Boardgames
@@ -61,9 +62,17 @@
                     </td>
                     <td>
                         <small>
-                            {% for owner in boardgame.currently_in_possession %}
-                                {{ owner.owner }}{% if not forloop.last %}, {% endif %}
-                            {% endfor %}
+                            {% if user|is_member %}
+                                {% for owner in boardgame.currently_in_possession %}
+                                    {{ owner.owner }}{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% else %}
+                                {% if boardgame.is_owned_by_association %}
+                                    Knights
+                                {% else %}
+                                    Loaned by member
+                                {% endif %}
+                            {% endif %}
                         </small>
                     </td>
                     <td>

--- a/membership_file/templatetags/to_member.py
+++ b/membership_file/templatetags/to_member.py
@@ -1,6 +1,8 @@
 from django import template
 from membership_file.util import user_to_member
 
+from membership_file.models import Member
+
 register = template.Library()
 
 ##################################################################################
@@ -11,3 +13,12 @@ register = template.Library()
 @register.filter
 def to_member(user):
     return user_to_member(user)
+
+@register.filter
+def is_member(user):
+    try:
+        if user.member:
+            return True
+    except (Member.DoesNotExist, AttributeError):
+        pass
+    return False


### PR DESCRIPTION
Boardgame list is a public list. However it did display the full names of members who owned the game without needing to be a member. Patched the leak by checking if current (anonymous)user is a member