### PR TITLE
Upgrade Pillow and djangorestframework

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,8 +5,8 @@
 Django~=2.2.2
 django-bootstrap4~=1.0
 django-cleanup~=4.0.0 # Removes old FileField files upon saving
-djangorestframework~=3.9.4
-Pillow~=7.2.0 # ImageField support
+djangorestframework~=3.12.4
+Pillow~=8.3.1 # ImageField support
 django-ical~=1.7.1 # iCalendar export
 django-recurrence~=1.10.3 # Recurring Dates
 django-import-export~=2.3.0 # Import/Export models


### PR DESCRIPTION
Pillow from 7.2.0 to 8.3.1
djangorestframework from 3.9.4 to 3.12.4

Should eventually refactor code to get rid of djangorestframework, which is currently only being used for serialization of Achievements and Members.