### PR TITLE
Newsletter share link as Global Dynamic Preference

### DIFF
--- a/core/dynamic_preferences_registry.py
+++ b/core/dynamic_preferences_registry.py
@@ -4,12 +4,31 @@ from django.contrib.auth.models import Permission
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from dynamic_preferences.types import ModelMultipleChoicePreference
+from dynamic_preferences.types import ModelMultipleChoicePreference, StringPreference
 from dynamic_preferences.preferences import Section
 from dynamic_preferences.registries import global_preferences_registry
 
-permissions = Section('permissions')
+##############################################################################
+# NEWSLETTER
+##############################################################################
 
+newsletter = Section('newsletter')
+
+@global_preferences_registry.register
+class NewsletterShareLink(StringPreference):
+    section = newsletter
+    name = 'share_link'
+    verbose_name = "Public Share Link"
+    description = 'A public link towards a page where anyone can view newsletters. For instance, can be a Nextcloud share URL.'
+    help_text = "Leave empty to disable the newsletter page."
+    default = ""
+    required = False
+
+
+##############################################################################
+# PERMISSIONS
+##############################################################################
+permissions = Section('permissions')
 
 # Permissions for everyone (including anonymous users)
 DEFAULT_BASE_PERMISSIONS = ()

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -67,7 +67,7 @@
                     <li>
                         <a class="nav-link" href="{% url 'roleplaying:home' %}">Roleplay</a>
                     </li>
-					{% if user.is_authenticated %}
+					{% if global_preferences.newsletter__share_link and user.is_authenticated %}
 						<li>
 							<a class="nav-link" href="{% url 'core:newsletters' %}">Newsletter</a>
 						</li>

--- a/core/views.py
+++ b/core/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMix
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
+from django.http.response import Http404, HttpResponseNotFound
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -15,6 +16,9 @@ from django.views.decorators.http import require_safe
 from .forms import RegisterForm
 from .managers import TemplateManager
 from .models import MarkdownImage
+
+from dynamic_preferences.registries import global_preferences_registry
+global_preferences = global_preferences_registry.manager()
 
 ##################################################################################
 # Contains render-code for displaying general pages.
@@ -34,8 +38,12 @@ def logoutSuccess(request):
 @require_safe
 @login_required
 def viewNewsletters(request):
+    share_link = global_preferences['newsletter__share_link']
+    if not share_link:
+        raise Http404("Newsletters are unavailable.")
+
     return render(request, 'core/newsletters.html', {
-        'NEWSLETTER_ARCHIVE_URL': settings.NEWSLETTER_ARCHIVE_URL,
+        'NEWSLETTER_ARCHIVE_URL': global_preferences['newsletter__share_link'],
     })
 
 

--- a/squire/settings.py
+++ b/squire/settings.py
@@ -345,9 +345,6 @@ APPLICATION_NAME = 'Squire'
 COMMITTEE_ABBREVIATION = 'UUPS'
 COMMITTEE_FULL_NAME = 'UUPS Ultraviolet Programmer Squad'
 
-# Share link to a 3rd party site where the newsletters are (temporarily) archived
-NEWSLETTER_ARCHIVE_URL = os.getenv('NEWSLETTER_ARCHIVE_URL') or None
-
 # The email address that error messages come from, such as those sent to ADMINS and MANAGERS.
 SERVER_EMAIL = f'{APPLICATION_NAME} Error <{APPLICATION_NAME.lower()}-error@kotkt.nl>'
 


### PR DESCRIPTION
The newsletter share link is no longer an environment variable, but can instead be set in the Admin panel through a Global Dynamic Preference.