### PR TITLE
Fixed participant name calling for users with members

### DIFF
--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -647,4 +647,4 @@ class Participant(models.Model):
         if self.guest_name:
             return self.guest_name + ' (ext)'
         else:
-            return self.user.get_simple_display_name()
+            return self.user.get_display_name()

--- a/activity_calendar/tests/test_models.py
+++ b/activity_calendar/tests/test_models.py
@@ -777,14 +777,17 @@ class ActivitySlotTestCase(TestCase):
 
 
 class ActivityParticipantTestCase(TestCase):
-    fixtures = ['test_users.json', 'test_activity_slots']
+    fixtures = ['test_users.json', 'test_members', 'test_activity_slots']
 
-    def test_str(self):
+    @patch('core.models.ExtendedUser.get_display_name', return_value='trigger_test')
+    def test_str(self, mock_function=None):
         participation = Participant.objects.create(
             user_id=1,
             activity_slot_id=7
         )
-        self.assertEqual(str(participation), 'test_admin')
+        # The method that should be triggered is overwritten as output is tested elsewhere
+        # We merely need to assure that it is used
+        self.assertEqual(str(participation), 'trigger_test')
 
         participation.guest_name = 'some guest'
         self.assertEqual(str(participation), participation.guest_name + ' (ext)')


### PR DESCRIPTION
Addressed issue where usernames were displayed in slots instead of member names