### PR TITLE
Bugfix: Internal Participants not shown for slotless activities

### DIFF
--- a/activity_calendar/templates/activity_calendar/activity_page_no_slots.html
+++ b/activity_calendar/templates/activity_calendar/activity_page_no_slots.html
@@ -71,7 +71,7 @@
         {% if subscribed_users or ext_participants %}
             {% for participant in subscribed_users %}
                 <div class="">
-                    {{ participant.get_display_name }}
+                    {{ participant }}
                 </div>
             {% endfor %}
             {% if subscribed_guests %}


### PR DESCRIPTION
Referenced method was removed in #177, and was replaced by __str__