### PR TITLE
Rewrote activity calendar for non-recurrency linked activitymoments

### DIFF
--- a/activity_calendar/feeds.py
+++ b/activity_calendar/feeds.py
@@ -1,20 +1,21 @@
 from datetime import datetime
 
 from django.conf import settings
+from django.urls import reverse_lazy
 from django.utils import timezone
 
-import django_ical.feedgenerator
-
+from django_ical import feedgenerator
+from django_ical.feedgenerator import ICal20Feed
 from django_ical.utils import build_rrule_from_recurrences_rrule
 from django_ical.views import ICalFeed
-from django_ical.feedgenerator import ICal20Feed
+
 
 from .models import Activity, ActivityMoment
 import activity_calendar.util as util
 
 # Monkey-patch; Why is this not open for extension in the first place?
-django_ical.feedgenerator.ITEM_EVENT_FIELD_MAP = (
-    *(django_ical.feedgenerator.ITEM_EVENT_FIELD_MAP),
+feedgenerator.ITEM_EVENT_FIELD_MAP = (
+    *(feedgenerator.ITEM_EVENT_FIELD_MAP),
     ('recurrenceid',    'recurrence-id'),
 )
 
@@ -144,7 +145,7 @@ class CESTEventFeed(ICalFeed):
         # When the item was generated, which is at this moment!
         return timezone.now()
 
-    @only_for(ActivityMoment, default="/activities/")
+    @only_for(ActivityMoment, default=reverse_lazy('activity_calendar:activity_upcoming'))
     def item_link(self, item):
         # The local url to the activity
         return item.get_absolute_url()

--- a/activity_calendar/fixtures/test_activity_slots.json
+++ b/activity_calendar/fixtures/test_activity_slots.json
@@ -132,6 +132,28 @@
     }
 },
 {
+    "model": "activity_calendar.activitymoment",
+    "pk": 5,
+    "fields": {
+        "parent_activity": 2,
+        "local_title": "Extra non-recurrent activity",
+        "recurrence_id": "2020-09-01T16:00:00Z",
+        "created_date": "2020-08-08T19:00:00Z",
+        "last_updated": "2020-08-08T19:00:00Z"
+    }
+},
+{
+    "model": "activity_calendar.activitymoment",
+    "pk": 6,
+    "fields": {
+        "parent_activity": 2,
+        "recurrence_id": "2020-09-30T14:00:00Z",
+        "local_start_date": "2020-09-30T16:20:00Z",
+        "created_date": "2020-10-08T19:00:00Z",
+        "last_updated": "2020-10-08T19:00:00Z"
+    }
+},
+{
   "model": "activity_calendar.activityslot",
   "pk": 1,
   "fields": {

--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -150,14 +150,10 @@ class Activity(models.Model):
         surplus_moments_queryset = self.activitymoment_set.filter(surplus_moments).values_list('recurrence_id', flat=True)
         recurrency_occurences = filter(lambda occ: occ not in surplus_moments_queryset, recurrency_occurences)
 
-        # Evaluate the iterable: we want to use it more than once below
-        recurrency_occurences = list(recurrency_occurences)
-
         # Fetch existing activitymoments
         #   They must either be within the bounds
         #   OR be extra ones due to different start/end date(s)
         query_filter = (activity_moments_between_query | extra_moments) & ~surplus_moments
-        # existing_moments = list(self.activitymoment_set.filter(query_filter))
         existing_moments = list(self.activitymoment_set.filter(query_filter))
 
         # Get occurrences for which we have no ActivityMoment

--- a/activity_calendar/tests/test_models.py
+++ b/activity_calendar/tests/test_models.py
@@ -437,6 +437,21 @@ class ActivityTestCase(TestCase):
             new_start_date=timezone.datetime(2020, 10, 13, 14, 0, 0, tzinfo=timezone.utc)
         )
 
+    def test_get_activitymoments_between_with_nonrecurring_extra_moment(self):
+        """
+            Tests that an activity occuring irregardless of the recurrence setup is returned. Just not as part of
+            that recurrence.
+        """
+        recurrence_id = timezone.datetime(2020, 10, 15, 10, 0, 0, tzinfo=timezone.utc)
+        self._test_get_activitymoments_between(
+            [
+                recurrence_id
+            ],
+            recurrence_id=recurrence_id,
+            after=timezone.datetime(2020, 10, 15, 8, 0, 0, tzinfo=timezone.utc),
+            before=timezone.datetime(2020, 10, 15, 23, 30, 0, tzinfo=timezone.utc)
+        )
+
     def test_get_activitymoments_between_extra_start_outside_bounds(self):
         """
             Tests if an occurrence with a recurrence_id outside the bounds of get_occurrences_between,


### PR DESCRIPTION
Activities now function as a group of activitymoments which _can_ be recurrent. But also allows additional activitymoments outside of the recurrency system