### PR TITLE
Upgrade Martor

### DIFF
--- a/core/fields.py
+++ b/core/fields.py
@@ -34,6 +34,8 @@ class MarkdownObject:
         """
             Returns the Markdown in html format.  E.g. <b>bold text</b>
             Tags not compiled by Markdown are escaped, meaning that it is safe to use.
+            Note that markdownify(..) strips HTML tags using django's strip_tags(..) before
+            applying markdown.
         """
         return mark_safe(markdownify(self.raw_value))
 

--- a/core/tests/tests_fields.py
+++ b/core/tests/tests_fields.py
@@ -36,8 +36,12 @@ class MarkdownObjectTest(TestCase):
 
     def test_html_escaped(self):
         """ Tests if HTML that is not created by markdown is escaped """
-        unsafe_text = "<script>alert('hello!')</script>"
-        escaped_text = "&lt;script&gt;alert(&lsquo;hello!&rsquo;)&lt;/script&gt;"
+        # Martor removes HTML tags using Django's (unsafe) strip_tags(..) prior to applying Markdown.
+        #   since martor 1.6.8.
+        #   We're purposely adding specific tokens and check if those're ACTUALLY escaped
+        #   to handle cases where strip_tags(..) would actually yield unsafe HTML.
+        unsafe_text = "<alert('hello!')<"
+        escaped_text = "&lt;alert(&lsquo;hello!&rsquo;)&lt;"
 
         md_object = MarkdownObject(unsafe_text)
         self.assertEqual(md_object.as_raw(), unsafe_text)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -11,6 +11,6 @@ django-ical~=1.7.1 # iCalendar export
 django-recurrence~=1.10.3 # Recurring Dates
 django-import-export~=2.3.0 # Import/Export models
 django-dynamic-preferences~=1.11.0 # Global Preferences / User Preferences
-martor~=1.6.4 # Markdown Editor
+martor~=1.6.8 # Markdown Editor
 pymdown-extensions~=8.1.1 # Extra markdown features
 django-pwa~=1.0.10


### PR DESCRIPTION
Fixes a broken testcase due to changes introduced in martor 1.6.8.
Martor 1.6.8 also removed an XSS option.

Martor also seems to remove all HTML tags prior to applying markdown. This seems like a bug, as valid markdown in things like code blocks:
```md
`<p>This is HTML text</p>`
```
now turns into:
```html
`This is HTML text`
```

This will probably not be encountered within Squire