### PR TITLE
April Fools 2022

### DIFF
--- a/core/dynamic_preferences_registry.py
+++ b/core/dynamic_preferences_registry.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import Permission
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from dynamic_preferences.types import ModelMultipleChoicePreference, StringPreference
+from dynamic_preferences.types import ModelMultipleChoicePreference, StringPreference, BooleanPreference
 from dynamic_preferences.preferences import Section
 from dynamic_preferences.registries import global_preferences_registry
 
@@ -23,6 +23,20 @@ class HomePageMessage(StringPreference):
     help_text = "Leave empty to not show any home page message."
     default = ""
     required = False
+
+
+@global_preferences_registry.register
+class April2022Active(BooleanPreference):
+    """
+        April 2022 message enabling. This should've probably been coded as a user theme instead,
+        but at the moment there's no easy way to make it the default & switch everyone to it,
+        nor can additional pages be added through it.
+    """
+    section = homepage
+    name = 'april_2022'
+    verbose_name = "April Fools 2022"
+    description = "When enabled, the April Fools 2022 messaging activates."
+    default = False
 
 ##############################################################################
 # COVID-19 / Corona

--- a/user_interaction/apps.py
+++ b/user_interaction/apps.py
@@ -6,6 +6,7 @@ class UserInteractionConfig(AppConfig):
 
     def ready(self):
         from membership_file.util import get_member_from_user
+        from dynamic_preferences.registries import global_preferences_registry
 
         def _get_user_display_name(user):
             """
@@ -19,6 +20,41 @@ class UserInteractionConfig(AppConfig):
                 - Real name set: <first_name>
             """
             member = get_member_from_user(user)
+
+            ################
+            # BEGIN APRIL 2022
+            ################
+            # Rename everyone to Dennis/Laura, and rename the actual ones to Sjors
+            global_preferences = global_preferences_registry.manager()
+            if global_preferences['homepage__april_2022']:
+                namelist = []
+                # Members
+                if member is not None:
+                    if member.first_name in ["Laura", "Dennis", "Denise"]:
+                        namelist.append("Sjors")
+                    elif len(member.first_name) % 2 == 0:
+                        namelist.append("Dennis")
+                    else:
+                        namelist.append("Laura")
+
+                    if member.tussenvoegsel:
+                        namelist.append(member.tussenvoegsel)
+
+                    namelist.append(member.last_name)
+                else:
+                    # Non-members
+                    namelist = (user.first_name or user.username).split()
+                    if namelist[0] in ["Laura", "Dennis", "Denise"]:
+                        namelist[0] = "Sjors"
+                    elif len(namelist[0]) % 2 == 0:
+                        namelist[0] = "Dennis"
+                    else:
+                        namelist[0] = "Laura"
+                return " ".join(namelist)
+            ################
+            # END APRIL 2022
+            ################
+
             if member is not None:
                 return member.get_full_name()
             return (user.first_name or user.username)

--- a/user_interaction/templates/user_interaction/april_2022.html
+++ b/user_interaction/templates/user_interaction/april_2022.html
@@ -1,0 +1,66 @@
+
+{% extends 'core/base.html' %}
+
+{% block title %}
+    Squire - Upgrade
+{% endblock title %}
+
+{% block og-title %}
+    Upgrade Squire
+{% endblock og-title %}
+
+{% block content-frame-class %}
+    wideContentFrame
+{% endblock %}
+
+{% block content %}
+    <!-- Adapted from Template: https://getbootstrap.com/docs/4.0/examples/pricing/ -->
+    <div class="pricing-header px-3 py-3 pt-md-4 pb-md-3 mx-auto text-center">
+        <h1 class="display-4">Squire 2.0</h1>
+        <p class="lead">Reshaping Urban Living Together</p>
+    </div>
+    <p class="pb-3">
+        Squire has been a victim of feature-creep since its release two years ago in 2020, and has as a result required more and more
+        resources to host. With the chip shortage and other components becoming more expensive with no visible end, we had to find a
+        solution to the ever-rising costs. Hence, we have decided to introduce <strong>Squire Premium</strong>.
+
+        All current Squire accounts will be migrated to <i>Squire Basic</i> by the end of next week.
+    </p>
+
+    <div class="container">
+        <div class="card-deck mb-3 text-center" style="max-width: 800px; margin-right: auto; margin-left: auto;">
+            <div class="card mb-4 box-shadow">
+                <div class="card-header">
+                    <h4 class="my-0 font-weight-normal">Squire Basic</h4>
+                </div>
+                <div class="card-body">
+                    <h1 class="card-title pricing-card-title">€0 <small class="text-muted">/ mo</small></h1>
+                    <ul class="list-unstyled mt-3 mb-4">
+                    <li>Advertisements</li>
+                    <li>Register for activities</li>
+                    <li>Earn achievements</li>
+                    <li>View committees</li>
+                    <li>Browse tabletop materials</li>
+                    </ul>
+                    <button type="button" disabled class="btn btn-lg btn-block btn-outline-primary">Current Plan</button>
+                </div>
+            </div>
+            <div class="card mb-4 box-shadow">
+                <div class="card-header">
+                    <h4 class="my-0 font-weight-normal">Squire Premium</h4>
+                </div>
+                <div class="card-body">
+                    <h1 class="card-title pricing-card-title">€20 <small class="text-muted">/ mo</small></h1>
+                    <ul class="list-unstyled mt-3 mb-4">
+                    <li>An ad-free experience</li>
+                    <li>An extra vote in Knights GMMs</li>
+                    <li>View anyone's membership details</li>
+                    <li>Priority email support</li>
+                    <li>All <i>Squire Basic</i> benefits</li>
+                    </ul>
+                    <a href="http://timheiszwolf.com/contact" class="btn btn-lg btn-block btn-primary">Get started</a>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/user_interaction/urls.py
+++ b/user_interaction/urls.py
@@ -9,6 +9,13 @@ def user_interaction_urls():
 
     urlpatterns = [
         path('', views.home_screen, name='homepage'),
+        ################
+        # BEGIN APRIL 2022
+        ################
+        path('upgrade', views.SquirePremiumView.as_view(), name='squire_premium'),
+        ################
+        # END APRIL 2022
+        ################
     ]
     return urlpatterns, app_name, app_name
 

--- a/user_interaction/views.py
+++ b/user_interaction/views.py
@@ -30,6 +30,14 @@ class HomeNonAuthenticatedView(TemplateView):
             **kwargs
         )
 
+################
+# BEGIN APRIL 2022
+################
+class SquirePremiumView(TemplateView):
+    template_name = "user_interaction/april_2022.html"
+################
+# END APRIL 2022
+################
 
 welcome_messages = [
     "Do not be alarmed by the Dragons. They're friendly :)",
@@ -79,6 +87,7 @@ class HomeUsersView(TemplateView):
 
     def get_unique_messages(self):
         unique_messages = []
+
         if global_preferences['homepage__home_page_message']:
             unique_messages.append({
                 'msg_text': str(global_preferences['homepage__home_page_message']),
@@ -93,5 +102,20 @@ class HomeUsersView(TemplateView):
                     'btn_text': "Continue Questing!",
                     'btn_url': reverse_lazy('membership_file/continue_membership'),
                 })
+
+        ################
+        # BEGIN APRIL 2022
+        ################
+        # Squire Premium
+        if global_preferences['homepage__april_2022']:
+            unique_messages.append({
+                'msg_text': "Squire 2.0 will release soon. Read about the details and new features it brings, and upgrade now!",
+                'msg_type': "danger",
+                'btn_text': "Visit Upgrade Page",
+                'btn_url': reverse_lazy('user_interaction:squire_premium'),
+            })
+        ################
+        # BEGIN APRIL 2022
+        ################
 
         return unique_messages


### PR DESCRIPTION
Renames members in the frontend (does not affect the database itself), and adds an "upgrade" page. Theming can be enabled/disabled through a checkbox in the global preferences admin.

Ideally this should've been coded as a user theme instead, but there was no easy way to enable that for users that are not logged in or switch everyone to it. Furthermore, a user theme does not allow adding a new page.