### PR TITLE
Slot images may not show

### DIFF
--- a/activity_calendar/models.py
+++ b/activity_calendar/models.py
@@ -134,7 +134,7 @@ class Activity(models.Model):
     subscriptions_close = models.DurationField(default=timezone.timedelta(hours=2))
 
     @property
-    def image_url(self):
+    def slots_image_url(self):
         if self.slots_image is None:
             return f'{settings.STATIC_URL}images/default_logo.png'
         return self.slots_image.image.url
@@ -614,7 +614,7 @@ class ActivityMoment(models.Model, metaclass=ActivityDuplicate):
         # Define fields that are instantly looked for in the parent_activity
         # If at any point in the future these must become customisable, one only has to move the field name to the
         # copy_fields attribute
-        link_fields = ['slots_image', 'subscriptions_required', 'display_end_time']
+        link_fields = ['slots_image_url', 'subscriptions_required', 'display_end_time']
 
     # Alternative start/end date of the activity. If left empty, matches the start/end time
     #   of this OCCURRENCE.
@@ -785,7 +785,7 @@ class ActivitySlot(models.Model):
     @property
     def image_url(self):
         if self.image is None:
-            return self.parent_activitymoment.slots_image
+            return self.parent_activitymoment.slots_image_url
         return self.image.image.url
 
     def get_subscribed_users(self):

--- a/activity_calendar/templates/activity_calendar/activity_page_base.html
+++ b/activity_calendar/templates/activity_calendar/activity_page_base.html
@@ -19,7 +19,7 @@
 {% block og-description %}
     [{{ activity_moment.start_date|date:"l j E H:i" }}] {{ activity_moment.description.as_plaintext|truncatewords:20 }}
 {% endblock og-description %}
-{% block og-image %}{% build_absolute_uri request activity.image_url %}{% endblock og-image %}
+{% block og-image %}{% build_absolute_uri request activity.slots_image_url %}{% endblock og-image %}
 {% block og-image-alt %}{{ activity_moment.title }} Icon{% endblock og-image-alt %}
 
 {% block css %}

--- a/activity_calendar/templates/activity_calendar/activity_page_cancelled.html
+++ b/activity_calendar/templates/activity_calendar/activity_page_cancelled.html
@@ -18,7 +18,7 @@
 {% block og-description %}
     [{{ activity_moment.start_date|date:"l j E H:i" }}] {{ activity_moment.description.as_plaintext|truncatewords:20 }}
 {% endblock og-description %}
-{% block og-image %}{% build_absolute_uri request activity.image_url %}{% endblock og-image %}
+{% block og-image %}{% build_absolute_uri request activity.slots_image_url %}{% endblock og-image %}
 {% block og-image-alt %}{{ activity_moment.title }} Icon{% endblock og-image-alt %}
 
 {% block css %}

--- a/activity_calendar/tests/tests_data_migrations.py
+++ b/activity_calendar/tests/tests_data_migrations.py
@@ -3,9 +3,11 @@ from datetime import timedelta
 from django.utils import dateparse
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 from recurrence import deserialize as deserialize_recurrence_test
+from unittest import skip
 
 from core.tests.util import suppress_warnings
 
+@skip("Old data migration tests don't need to be run")
 class ActivitySlotLinkToActivityMomentTest(MigratorTestCase):
     """
         ActivitySlots used to be linked to Activities (with a recurrence_id) directly, but


### PR DESCRIPTION
ActivitySlots without their own PresetImage do not show any image at all, rather than inheriting them from their parent activity(moment). Instance methods were renamed to be clearer of what they represent.

Also disables tests for an old data migration. There's no point in continuously running these.