### PR TITLE
Fixed unique property in migration file

### DIFF
--- a/committees/migrations/0006_add_and_fill_name_field.py
+++ b/committees/migrations/0006_add_and_fill_name_field.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='associationgroup',
             name='name',
-            field=models.CharField(default='fake_name', max_length=150, unique=True),
+            field=models.CharField(default='fake_name', max_length=150),
             preserve_default=False,
         ),
         migrations.AlterField(
@@ -46,5 +46,10 @@ class Migration(migrations.Migration):
             name='site_group',
             field=models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='auth.Group'),
         ),
-        migrations.RunPython(forwards_func, reverse_func)
+        migrations.RunPython(forwards_func, reverse_func),
+        migrations.AlterField(
+            model_name='associationgroup',
+            name='name',
+            field=models.CharField(max_length=150, unique=True),
+        ),
     ]


### PR DESCRIPTION
In association_group a unique field name was added before it was populated, causing an error as an empty string was not unique.