### PR TITLE
Fix: Inactive committee members (display) + multiple global archive addresses

### DIFF
--- a/mailcow_integration/admin_status/views.py
+++ b/mailcow_integration/admin_status/views.py
@@ -140,7 +140,7 @@ class MailcowStatusView(TemplateView):
             blocklist += self.mailcow_manager.BLOCKLISTED_EMAIL_ADDRESSES
             if alias_type == AliasCategory.GLOBAL_COMMITTEE:
                 email_field = "contact_email"
-                get_name = lambda sub: f"{sub.site_group.name} ({sub.get_type_display()})"
+                get_name = lambda sub: f"{sub.name} ({sub.get_type_display()})"
             else:
                 blocklist += self._committee_addresses
 
@@ -209,8 +209,8 @@ class MailcowStatusView(TemplateView):
                 aliases, mailboxes, self.mailcow_manager.ALIAS_COMMITTEE_PUBLIC_COMMENT)
 
             subscribers = self._get_subscriberinfos_by_status(status, subscribers, alias)
-            info = AliasInfos(status.name, subscribers, address, "c_" + str(assoc_group.id), assoc_group.site_group.name,
-                format_html("{} ({}): {}", assoc_group.site_group.name, assoc_group.get_type_display(), assoc_group.short_description),
+            info = AliasInfos(status.name, subscribers, address, "c_" + str(assoc_group.id), assoc_group.name,
+                format_html("{} ({}): {}", assoc_group.name, assoc_group.get_type_display(), assoc_group.short_description),
                 alias or mailbox, False, squire_edit_url=reverse("admin:committees_associationgroup_change", args=[assoc_group.id]),
                 archive_addresses=settings.COMMITTEE_CONFIGS['archive_addresses']
             )

--- a/mailcow_integration/admin_status/views.py
+++ b/mailcow_integration/admin_status/views.py
@@ -189,8 +189,8 @@ class MailcowStatusView(TemplateView):
             if not self.mailcow_manager.is_address_internal(address) and status != AliasStatus.RESERVED:
                 exp_routes = [[address, "Alias not located in Rspamd settings map."]]
 
-            subscribers = self._get_subscriberinfos_by_status(status, subscribers, alias, alias_type=AliasCategory.GLOBAL_COMMITTEE)
-            info = AliasInfos(status.name, subscribers, address, "gc_" + alias_address_to_id(address), address,
+            info_subscribers = self._get_subscriberinfos_by_status(status, subscribers, alias, alias_type=AliasCategory.GLOBAL_COMMITTEE)
+            info = AliasInfos(status.name, info_subscribers, address, "gc_" + alias_address_to_id(address), address,
                 "Allows mailing all committees at the same time.",
                 alias or mailbox, internal=True, exposure_routes=exp_routes, allow_opt_out=None, archive_addresses=settings.COMMITTEE_CONFIGS['global_archive_addresses']
             )
@@ -203,7 +203,7 @@ class MailcowStatusView(TemplateView):
 
         for assoc_group in self.mailcow_manager.get_active_committees():
             address = assoc_group.contact_email
-            subscribers = assoc_group.members.filter_active().order_by('email')
+            subscribers = assoc_group.members.order_by('email')
 
             status, alias, mailbox = self._get_alias_status(address, subscribers, AliasCategory.COMMITTEE,
                 aliases, mailboxes, self.mailcow_manager.ALIAS_COMMITTEE_PUBLIC_COMMENT)

--- a/mailcow_integration/tests/tests_view_status.py
+++ b/mailcow_integration/tests/tests_view_status.py
@@ -403,8 +403,8 @@ class MailcowStatusInitializersTests(MailcowStatusViewTests):
         # AliasInfos returned
         self.assertListEqual(status, [ AliasInfos(
             AliasStatus.VALID.name, [],
-            committee.contact_email, "c_" + str(committee.id), committee.site_group.name,
-            format_html("{} ({}): {}", committee.site_group.name, committee.get_type_display(), committee.short_description),
+            committee.contact_email, "c_" + str(committee.id), committee.name,
+            format_html("{} ({}): {}", committee.name, committee.get_type_display(), committee.short_description),
             None, False, squire_edit_url=reverse("admin:committees_associationgroup_change", args=[committee.id]),
             archive_addresses=["archief@example.com"]
         )])

--- a/mailcow_integration/tests/tests_view_status.py
+++ b/mailcow_integration/tests/tests_view_status.py
@@ -181,7 +181,7 @@ class MailcowSubscriberInfosTests(MailcowStatusViewTests):
         self.assertEqual(subinfos[1], {'name': "Foo Oof &mdash; foo@example.com", 'invalid': True})
 
         # Committee Subscribers
-        AssociationGroup.objects.create(site_group=Group.objects.create(name="Boardgamers"),
+        AssociationGroup.objects.create(name="Boardgamers",
             type=AssociationGroup.COMMITTEE, contact_email="bg@example.com")
         subinfos = self.view._get_subscriberinfos_by_status(AliasStatus.VALID, AssociationGroup.objects.all(), None, AliasCategory.GLOBAL_COMMITTEE)
         self.assertEqual(len(subinfos), 1)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -11,7 +11,7 @@ django-ical~=1.8.3 # iCalendar export
 django-recurrence~=1.11.1 # Recurring Dates
 django-import-export~=2.8.0 # Import/Export models
 django-dynamic-preferences~=1.14.0 # Global Preferences / User Preferences
-martor~=1.6.14 # Markdown Editor
+martor~=1.6.14, <=1.6.26; # Markdown Editor
 pymdown-extensions~=9.5 # Extra markdown features
 django-pwa~=1.0.10 # Progressive Webapp
 requests~=2.28.1 # Requests (needed for Mailcow API)


### PR DESCRIPTION
Fixed an issue where the server status page incorrectly mentioned a committee alias was outdated when an inactive member was part of that committee. Actual behaviour is unchanged; inactive members were still added to the committee's alias (as intended).

Fixed an issue where a crash would occur when multiple global committee archive addresses were set up in `mailcowconfig.json`