### PR TITLE
Update Mailcow API 2024-08a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ htdocs/static
 /squire/local_settings.py
 /squire/mailcowconfig.json
 /squire/secret_key.txt
+/squire/config
 
 # Disables tracking of membership Card file, need to be added manually
 /membership_file/static/images/MembershipCard.jpg

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ htdocs/media/images/*
 htdocs/static
 /output/
 /test/output/
+/squire/logs
 
 # Secrets
 /squire/local_settings.py

--- a/core/admin_status/config.py
+++ b/core/admin_status/config.py
@@ -1,0 +1,16 @@
+from django.urls import path
+from core.admin_status.views import LogFileView
+from core.status_collective import AdminStatusBaseConfig
+
+
+class LogConfig(AdminStatusBaseConfig):
+    url_keyword = "logs"
+    name = "Logs"
+    icon_class = "fas fa-bug"
+    url_name = "logs"
+    order_value = 2  # Value determining the order of the tabs on the admin status page
+
+    def get_urls(self):
+        return [
+            path("log", LogFileView.as_view(config=self), name="logs"),
+        ]

--- a/core/admin_status/views.py
+++ b/core/admin_status/views.py
@@ -1,0 +1,88 @@
+from io import BufferedReader
+import os
+import re
+from django.conf import settings
+from django.views.generic import TemplateView
+
+from django.utils.safestring import SafeText
+from django.utils.html import escape, format_html
+
+from core.status_collective import AdminStatusViewMixin
+
+
+class LogFileView(AdminStatusViewMixin, TemplateView):
+    """
+    TODO
+    """
+
+    tags = {
+        re.escape("[debug]"): "text-secondary font-weight-bold",
+        re.escape("[info]"): "text-info font-weight-bold",
+        re.escape("[warning]"): "text-warning font-weight-bold",
+        re.escape("[error]"): "text-danger font-weight-bold",
+        re.escape("TypeError"): "font-weight-bold",
+        re.escape("(mailcow_api)"): "far fa-envelope text-primary",
+        "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}": "far fa-clock text-muted",
+    }
+
+    template_name = "core/admin_status/log.html"
+    log_location = os.path.join(settings.BASE_DIR, "squire", "logs", "squire.log")
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._logfile1 = None
+        self._logfile2 = None
+        self._logfile1_name = None
+        self._logfile2_name = None
+
+        try:
+            with open(self.log_location, "r") as fl:
+                data = fl.read()
+                log1_peek = data[:23]
+                self._logfile1 = self._format_logfile(data)
+                self._logfile1_name = os.path.join("squire", "logs", "squire.log")
+        except OSError:
+            pass
+        try:
+            with open(self.log_location + ".1", "r") as fl:
+                data = fl.read()
+                if data[:23] < log1_peek:
+                    self._logfile2 = self._logfile1
+                    self._logfile1 = self._format_logfile(data)
+                    self._logfile1_name = os.path.join("squire", "logs", "squire.log.1")
+                    self._logfile2_name = os.path.join("squire", "logs", "squire.log")
+                else:
+                    self._logfile2 = self._format_logfile(data)
+                    self._logfile2_name = os.path.join("squire", "logs", "squire.log.1")
+        except OSError:
+            pass
+
+    def _format_logfile(self, data: str) -> SafeText:
+        """TODO"""
+        text = escape(data)
+        text = re.sub("(\r\n|\r|\n)", "<br>", text)
+        for string, classes in self.tags.items():
+            text = SafeText(
+                re.sub(
+                    rf"(?i)(\b|(?!\w))({string})(\b|(?!\w))",
+                    rf"\g<1><span class='{classes}'>\g<2></span>\g<3>",
+                    text,
+                )
+            )
+        return text
+
+    def _format_logline(self, line: str) -> SafeText:
+        """TODO"""
+        # format_html("{}")
+
+        print()
+
+        # xxx = "".replace(new RegExp(`(\\b)(${text})(\\b)`, 'gi'), `$1<span class='${styles[className]}'>$2<\/span>$3`)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["log1"] = self._logfile1
+        context["log2"] = self._logfile2
+        context["log1_name"] = self._logfile1_name
+        context["log2_name"] = self._logfile2_name
+        return context

--- a/core/admin_status/views.py
+++ b/core/admin_status/views.py
@@ -1,28 +1,28 @@
-from io import BufferedReader
 import os
 import re
 from django.conf import settings
 from django.views.generic import TemplateView
 
 from django.utils.safestring import SafeText
-from django.utils.html import escape, format_html
+from django.utils.html import escape
 
 from core.status_collective import AdminStatusViewMixin
 
 
 class LogFileView(AdminStatusViewMixin, TemplateView):
     """
-    TODO
+    A simple page that allows viewing the content of rotating log files in `/squire/logs/squire.log.<number>`
     """
 
     tags = {
+        "&lt;[a-z0-9_\-:\s]*&gt;": "text-danger",
+        "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(,[0-9]{3})?": "far fa-clock text-muted",
         re.escape("[debug]"): "text-secondary font-weight-bold",
         re.escape("[info]"): "text-info font-weight-bold",
         re.escape("[warning]"): "text-warning font-weight-bold",
         re.escape("[error]"): "text-danger font-weight-bold",
-        re.escape("TypeError"): "font-weight-bold",
+        re.escape("JSONParseError"): "font-weight-bold",
         re.escape("(mailcow_api)"): "far fa-envelope text-primary",
-        "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}": "far fa-clock text-muted",
     }
 
     template_name = "core/admin_status/log.html"
@@ -35,9 +35,12 @@ class LogFileView(AdminStatusViewMixin, TemplateView):
         self._logfile1_name = None
         self._logfile2_name = None
 
+        # Open both logfiles, reverse the log's lines (most recent at the top),
+        #   and make sure the most recent rotating logfile appears first.
         try:
             with open(self.log_location, "r") as fl:
-                data = fl.read()
+                data = "".join(reversed(fl.readlines()))
+                # The log format is known; the first 23 chars are an ISO-timestamp
                 log1_peek = data[:23]
                 self._logfile1 = self._format_logfile(data)
                 self._logfile1_name = os.path.join("squire", "logs", "squire.log")
@@ -45,8 +48,8 @@ class LogFileView(AdminStatusViewMixin, TemplateView):
             pass
         try:
             with open(self.log_location + ".1", "r") as fl:
-                data = fl.read()
-                if data[:23] < log1_peek:
+                data = "".join(reversed(fl.readlines()))
+                if data[:23] > log1_peek:
                     self._logfile2 = self._logfile1
                     self._logfile1 = self._format_logfile(data)
                     self._logfile1_name = os.path.join("squire", "logs", "squire.log.1")
@@ -58,9 +61,8 @@ class LogFileView(AdminStatusViewMixin, TemplateView):
             pass
 
     def _format_logfile(self, data: str) -> SafeText:
-        """TODO"""
+        """Formats a logfile by adding 'syntax' highlighting to specific keywords defined in this class's `tags`."""
         text = escape(data)
-        text = re.sub("(\r\n|\r|\n)", "<br>", text)
         for string, classes in self.tags.items():
             text = SafeText(
                 re.sub(
@@ -69,15 +71,8 @@ class LogFileView(AdminStatusViewMixin, TemplateView):
                     text,
                 )
             )
+        text = SafeText(re.sub("(\r\n|\r|\n)", "<br>", text))
         return text
-
-    def _format_logline(self, line: str) -> SafeText:
-        """TODO"""
-        # format_html("{}")
-
-        print()
-
-        # xxx = "".replace(new RegExp(`(\\b)(${text})(\\b)`, 'gi'), `$1<span class='${styles[className]}'>$2<\/span>$3`)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/core/templates/core/admin_status/log.html
+++ b/core/templates/core/admin_status/log.html
@@ -1,0 +1,34 @@
+
+{% extends 'core/base.html' %}
+
+{% load static %}
+{% load bootstrap_tabs %}
+
+{% block title %}
+  Logging
+{% endblock title %}
+
+{% block content-frame-class %}
+    wideContentFrame
+{% endblock %}
+
+{% block css %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'css/bootstrap_tabs.css' %}">
+{% endblock css %}
+
+{% block content %}
+    {% bootstrap_tabs tabs %}
+    <h1>Logs</h1>
+    <h4>{{ log1_name }}</h4>
+    <samp class="text-break">{{ log1 }}</samp>
+    <hr>
+    <h4>{{ log2_name }}</h4>
+    <samp>{{ log2 }}</samp>
+    <hr>
+{% endblock content %}
+
+{% block js_bottom %}
+    {{ block.super }}
+    <script src="{% static "js/activate_bootstrap_tooltip.js" %}"></script>
+{% endblock %}

--- a/core/templates/core/admin_status/log.html
+++ b/core/templates/core/admin_status/log.html
@@ -8,10 +8,6 @@
   Logging
 {% endblock title %}
 
-{% block content-frame-class %}
-    wideContentFrame
-{% endblock %}
-
 {% block css %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'css/bootstrap_tabs.css' %}">
@@ -20,12 +16,28 @@
 {% block content %}
     {% bootstrap_tabs tabs %}
     <h1>Logs</h1>
-    <h4>{{ log1_name }}</h4>
-    <samp class="text-break">{{ log1 }}</samp>
-    <hr>
-    <h4>{{ log2_name }}</h4>
-    <samp>{{ log2 }}</samp>
-    <hr>
+    <p>Logging created by various modules. Logs are written to two rotating files sizing (at most) 5MB each.</p>
+    {% if log1 is not None %}
+        <h4>{{ log1_name }}</h4>
+        {% if not log1 %}
+            <p class="font-italic">No logging written.</p>
+        {% else %}
+            <samp class="text-break">{{ log1 }}</samp>
+        {% endif %}
+        <hr>
+    {% endif %}
+    {% if log2 is not None %}
+        <h4>{{ log2_name }}</h4>
+        {% if not log2 %}
+            <p class="font-italic">No logging written.</p>
+        {% else %}
+            <samp class="text-break">{{ log2 }}</samp>
+        {% endif %}
+        <hr>
+    {% endif %}
+    {% if log1 is None and log2 is None %}
+        <p class="font-italic">No logging written.</p>
+    {% endif %}
 {% endblock content %}
 
 {% block js_bottom %}

--- a/mailcow_integration/api/client.py
+++ b/mailcow_integration/api/client.py
@@ -101,12 +101,12 @@ class MailcowAPIClient:
     def get_alias_all(self) -> Generator[Optional[MailcowAlias], None, None]:
         """Gets a list of all email aliases"""
         content = self._make_request(f"get/alias/all")
-        return map(lambda alias: MailcowAlias.from_json_safe(alias), content)
+        return map(lambda alias: MailcowAlias.from_json(alias), content)
 
     def get_alias(self, id: int) -> Optional[MailcowAlias]:
         """Gets an email alias with a specific id"""
         content = self._make_request(f"get/alias/{id}")
-        return MailcowAlias.from_json_safe(content)
+        return MailcowAlias.from_json(content)
 
     def update_alias(self, alias: MailcowAlias) -> dict:
         """Updates an alias"""
@@ -179,7 +179,7 @@ class MailcowAPIClient:
     def get_mailbox_all(self) -> Generator[Optional[MailcowMailbox], None, None]:
         """Gets a list of all mailboxes"""
         content = self._make_request(f"get/mailbox/all")
-        return map(lambda mailbox: MailcowMailbox.from_json_safe(mailbox), content)
+        return map(lambda mailbox: MailcowMailbox.from_json(mailbox), content)
 
     ################
     # RSPAMD SETTINGS (undocumented API)
@@ -187,12 +187,12 @@ class MailcowAPIClient:
     def get_rspamd_setting_all(self) -> Generator[Optional[RspamdSettings], None, None]:
         """Gets all Rspamd settings maps"""
         content = self._make_request("get/rsetting/all")
-        return map(lambda rspamdsetting: RspamdSettings.from_json_safe(rspamdsetting), content)
+        return map(lambda rspamdsetting: RspamdSettings.from_json(rspamdsetting), content)
 
     def get_rspamd_setting(self, id: int) -> Optional[RspamdSettings]:
         """Gets an Rspamd settings map with a specific id"""
         content = self._make_request(f"get/rsetting/{id}")
-        return RspamdSettings.from_json_safe(content)
+        return RspamdSettings.from_json(content)
 
     def update_rspamd_setting(self, setting: RspamdSettings) -> dict:
         """Updates the RspamdSetting associated to the given ID with the given data"""

--- a/mailcow_integration/api/client.py
+++ b/mailcow_integration/api/client.py
@@ -2,7 +2,7 @@ from enum import Enum
 import json
 import logging
 import requests
-from typing import Generator, List, Union
+from typing import Generator, List, Optional, Union
 
 from mailcow_integration.api.exceptions import *
 from mailcow_integration.api.interface.alias import AliasType, MailcowAlias
@@ -98,15 +98,15 @@ class MailcowAPIClient:
     ################
     # ALIASES
     ################
-    def get_alias_all(self) -> Generator[MailcowAlias, None, None]:
+    def get_alias_all(self) -> Generator[Optional[MailcowAlias], None, None]:
         """Gets a list of all email aliases"""
         content = self._make_request(f"get/alias/all")
-        return map(lambda alias: MailcowAlias.from_json(alias), content)
+        return map(lambda alias: MailcowAlias.from_json_safe(alias), content)
 
-    def get_alias(self, id: int) -> MailcowAlias:
+    def get_alias(self, id: int) -> Optional[MailcowAlias]:
         """Gets an email alias with a specific id"""
         content = self._make_request(f"get/alias/{id}")
-        return MailcowAlias.from_json(content)
+        return MailcowAlias.from_json_safe(content)
 
     def update_alias(self, alias: MailcowAlias) -> dict:
         """Updates an alias"""
@@ -176,23 +176,23 @@ class MailcowAPIClient:
     ################
     # MAILBOXES
     ################
-    def get_mailbox_all(self) -> Generator[MailcowMailbox, None, None]:
+    def get_mailbox_all(self) -> Generator[Optional[MailcowMailbox], None, None]:
         """Gets a list of all mailboxes"""
         content = self._make_request(f"get/mailbox/all")
-        return map(lambda mailbox: MailcowMailbox.from_json(mailbox), content)
+        return map(lambda mailbox: MailcowMailbox.from_json_safe(mailbox), content)
 
     ################
     # RSPAMD SETTINGS (undocumented API)
     ################
-    def get_rspamd_setting_all(self) -> Generator[RspamdSettings, None, None]:
+    def get_rspamd_setting_all(self) -> Generator[Optional[RspamdSettings], None, None]:
         """Gets all Rspamd settings maps"""
         content = self._make_request("get/rsetting/all")
-        return map(lambda rspamdsetting: RspamdSettings.from_json(rspamdsetting), content)
+        return map(lambda rspamdsetting: RspamdSettings.from_json_safe(rspamdsetting), content)
 
-    def get_rspamd_setting(self, id: int) -> RspamdSettings:
+    def get_rspamd_setting(self, id: int) -> Optional[RspamdSettings]:
         """Gets an Rspamd settings map with a specific id"""
         content = self._make_request(f"get/rsetting/{id}")
-        return RspamdSettings.from_json(content)
+        return RspamdSettings.from_json_safe(content)
 
     def update_rspamd_setting(self, setting: RspamdSettings) -> dict:
         """Updates the RspamdSetting associated to the given ID with the given data"""

--- a/mailcow_integration/api/interface/base.py
+++ b/mailcow_integration/api/interface/base.py
@@ -1,8 +1,21 @@
 from abc import ABC, abstractmethod
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("mailcow_api")
 
 
 class MailcowAPIResponse(ABC):
     """Abstract base class for Mailcow API responses"""
+
+    @classmethod
+    def from_json_safe(cls, json: dict) -> Optional["MailcowAPIResponse"]:
+        """Create a response object from a JSON response, or `None` if the JSON is invalid"""
+        try:
+            return cls.from_json(json)
+        except TypeError as e:
+            logger.warning(f"TypeError: {cls.__name__}.{e}")
+        return None
 
     @classmethod
     @abstractmethod

--- a/mailcow_integration/api/interface/base.py
+++ b/mailcow_integration/api/interface/base.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
+from enum import Enum
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Set, Tuple
 
 logger = logging.getLogger("mailcow_api")
 
@@ -8,17 +10,135 @@ logger = logging.getLogger("mailcow_api")
 class MailcowAPIResponse(ABC):
     """Abstract base class for Mailcow API responses"""
 
-    @classmethod
-    def from_json_safe(cls, json: dict) -> Optional["MailcowAPIResponse"]:
-        """Create a response object from a JSON response, or `None` if the JSON is invalid"""
-        try:
-            return cls.from_json(json)
-        except TypeError as e:
-            logger.warning(f"TypeError: {cls.__name__}.{e}")
-        return None
+    _cleanable_bools: Tuple[str, ...] = ()
+    _cleanable_strings: Tuple[str, ...] = ()
+    _cleanable_ints: Tuple[str, ...] = ()
+    _cleanable_datetimes: Tuple[str, ...] = ()
 
     @classmethod
-    @abstractmethod
-    def from_json(cls, json: dict) -> "MailcowAPIResponse":
-        """Create a response object from a JSON response"""
-        raise NotImplementedError("Subclasses should define a `from_json` method")
+    def _issue_warning(cls, fieldname: str, value, parse_value=""):
+        """Writes a warning about field parsing"""
+        msg = f"JSONParseError in {cls.__name__}: Missing required field <{fieldname}>"
+        if value is not None:
+            msg = f"JSONParseError in {cls.__name__}: Field <{fieldname}> value could not be parsed as {parse_value}: <{value}>"
+        logger.warning(msg)
+
+    @classmethod
+    def _issue_extra_warning(cls, fieldname: str, value):
+        """Writes a warning about extra fields"""
+        logger.warning(f"JSONParseError in {cls.__name__}: Found extra field <{fieldname}> with value <{value}>")
+
+    @classmethod
+    def _parse_as_bool(cls, fieldname: str, json: dict, default=None) -> Optional[bool]:
+        """Parse a field from JSON as a boolean, or issue a warning"""
+        val = json.get(fieldname, None)
+        if val in ("0", "1"):
+            # Sometimes booleans are returned as "0"/"1"
+            return val == "1"
+        elif isinstance(val, bool) or val in (0, 1):
+            # Booleans sometimes returned as True/False, sometimes as 0/1
+            return bool(val)
+        cls._issue_warning(fieldname, val, "bool")
+        return default
+
+    @classmethod
+    def _parse_as_string(cls, fieldname: str, json: dict, default=None) -> Optional[str]:
+        """Parse a field from JSON as a string, or issue a warning"""
+        val = json.get(fieldname, None)
+        if val is not None:
+            return str(val)
+        cls._issue_warning(fieldname, val, "string")
+        return default
+
+    @classmethod
+    def _parse_as_int(cls, fieldname: str, json: dict, default=None) -> Optional[int]:
+        """Parse a field from JSON as an int, or issue a warning"""
+        val = json.get(fieldname, None)
+        if isinstance(val, int):
+            return val
+        cls._issue_warning(fieldname, val, "int")
+        return default
+
+    @classmethod
+    def _parse_as_dt(cls, fieldname: str, json: dict, default=None) -> Optional[datetime]:
+        """Parse a field from JSON as a datetime, or issue a warning"""
+        val = json.get(fieldname, None)
+        try:
+            # Datetimes are sometimes returned in ISO-format, sometimes as a timestamp, sometimes as "0"
+            if val == "0" or isinstance(val, int):
+                return None if str(val) == "0" else datetime.fromtimestamp(val)
+            return datetime.fromisoformat(val)
+        except (ValueError, TypeError):
+            cls._issue_warning(fieldname, val, "ISO-datetime")
+            return default
+
+    @classmethod
+    def _parse_as_enum(cls, fieldname: str, json: dict, enum: Enum, default=None) -> Optional[Enum]:
+        """Parse a field from JSON as an Enum, or issue a warning"""
+        val = json.get(fieldname, None)
+        try:
+            return enum(val)
+        except ValueError:
+            cls._issue_warning(fieldname, val, f"{enum.__class__.__name__} (Enum)")
+            return default
+
+    @classmethod
+    def clean(cls, json: dict, extra_keys: Set[str] = None) -> dict:
+        """
+        Validates and removes invalidated fields from the JSON. By default this
+        looks at the various `cls._cleanable_<foo>` fields, but custom behaviour
+        can be implemented in subclasses by overriding this method.
+
+        Issues warnings through this file's `logger` when additional fields are returned
+        by the MailCow API, when fields are expected by Squire('s dataclass) but not returned
+        by the Mailcow API, or when a value returned by the Mailcow API cannot be parsed in the
+        expected format (e.g. a boolean but '3' was returned).
+
+        :raise: `AttributeError` if the JSON cannot be serialized into a MailcowAPIResponse
+            (e.g. critical data is missing or has the wrong format)
+        """
+        extra_keys = extra_keys or set()
+
+        # Show warning for extra attributes
+        extra_attrs = json.keys() - (
+            set(cls._cleanable_bools)
+            | set(cls._cleanable_strings)
+            | set(cls._cleanable_ints)
+            | set(cls._cleanable_datetimes)
+            | extra_keys
+        )
+
+        for attr in extra_attrs:
+            cls._issue_extra_warning(attr, json[attr])
+
+        cleaned_data = {}
+        # Verify boolean fields
+        for bool_field in cls._cleanable_bools:
+            if (val := cls._parse_as_bool(bool_field, json)) is not None:
+                cleaned_data[bool_field] = val
+
+        # Verify string fields
+        for string_field in cls._cleanable_strings:
+            if (val := cls._parse_as_string(string_field, json)) is not None:
+                cleaned_data[string_field] = val
+
+        # Verify int fields
+        for int_field in cls._cleanable_ints:
+            if (val := cls._parse_as_int(int_field, json)) is not None:
+                cleaned_data[int_field] = val
+
+        # Verify datetime fields
+        for dt_field in cls._cleanable_datetimes:
+            if (val := cls._parse_as_dt(dt_field, json)) is not None:
+                cleaned_data[dt_field] = val
+
+        return cleaned_data
+
+    @classmethod
+    def from_json(cls, json: dict):
+        """Create an instance from a JSON response, or `None` if this was not possible"""
+        try:
+            json = cls.clean(json)
+        except AttributeError:
+            return None
+        return cls(**json)

--- a/mailcow_integration/api/interface/mailbox.py
+++ b/mailcow_integration/api/interface/mailbox.py
@@ -147,7 +147,7 @@ class MailcowMailbox(MailcowAPIResponse):
                     datetime.fromtimestamp(int(json["last_pop3_login"])) if json["last_pop3_login"] != "0" else None
                 ),
                 "pushover_active": bool(json["pushover_active"]),
-                "attributes": MailboxAttributes.from_json(json["attributes"]),
+                "attributes": MailboxAttributes.from_json_safe(json["attributes"]) or MailboxAttributes(),
             }
         )
         return cls(**json)

--- a/mailcow_integration/api/interface/mailbox.py
+++ b/mailcow_integration/api/interface/mailbox.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from mailcow_integration.api.interface.base import MailcowAPIResponse
 
@@ -48,33 +48,49 @@ class MailboxAttributes(MailcowAPIResponse):
     mailbox_format: str = "maildir:"  # ??? E.g. 'maildir:'
     quarantine_notification: QuarantineNotification = QuarantineNotification.NEVER
     quarantine_category: QuarantaineNotificationCategory = QuarantaineNotificationCategory.REJECT
-    passwd_update: bool = False
+    passwd_update: Optional[datetime] = None  # When a password was last updated
     relayhost: bool = False
     sieve_access: bool = False
     recovery_email: str = ""
 
+    _cleanable_bools = (
+        "force_pw_update",
+        "tls_enforce_in",
+        "tls_enforce_out",
+        "sogo_access",
+        "imap_access",
+        "pop3_access",
+        "smtp_access",
+        "xmpp_access",
+        "xmpp_admin",
+        "relayhost",
+        "sieve_access",
+    )
+    _cleanable_strings = ("mailbox_format",)
+    _cleanable_datetimes = ("passwd_update",)
+
     @classmethod
-    def from_json(cls, json: dict) -> "MailboxAttributes":
-        json.update(
-            {
-                "force_pw_update": json["force_pw_update"] != "0",
-                "tls_enforce_in": json["tls_enforce_in"] != "0",
-                "tls_enforce_out": json["tls_enforce_out"] != "0",
-                "sogo_access": json["sogo_access"] != "0",
-                "imap_access": json["imap_access"] != "0",
-                "pop3_access": json["pop3_access"] != "0",
-                "smtp_access": json["smtp_access"] != "0",
-                "xmpp_access": json["xmpp_access"] != "0",
-                "xmpp_admin": json["xmpp_admin"] != "0",
-                "quarantine_notification": QuarantineNotification(json["quarantine_notification"]),
-                "quarantine_category": QuarantaineNotificationCategory(json["quarantine_category"]),
-                "passwd_update": json["passwd_update"] != "0",
-                "relayhost": json["relayhost"] != "0",
-                "sieve_access": json["sieve_access"] != "0",
-                "recovery_email": json.get("recovery_email", ""),
-            }
-        )
-        return cls(**json)
+    def clean(cls, json: dict, extra_keys: Set[str] = None):
+        new_json = {}
+
+        # Quarantine
+        notif = cls._parse_as_enum("quarantine_notification", json, QuarantineNotification)
+        if notif is not None:
+            new_json["quarantine_notification"] = notif
+
+        cat = cls._parse_as_enum("quarantine_category", json, QuarantaineNotificationCategory)
+        if cat is not None:
+            new_json["quarantine_category"] = cat
+
+        # Recovery email can be '' or absent from the JSON when it is not set
+        rec = json.get("recovery_email", None)
+        if rec is not None:
+            new_json["recovery_email"] = str(rec)
+
+        extra_keys = extra_keys or set()
+        new_json.update(**super().clean(json, extra_keys=new_json.keys() | extra_keys))
+
+        return new_json
 
 
 @dataclass
@@ -105,9 +121,6 @@ class MailcowMailbox(MailcowAPIResponse):
     last_smtp_login: Optional[datetime] = None
     last_pop3_login: Optional[datetime] = None
 
-    domain_xmpp: int = 0
-    domain_xmpp_prefix: str = ""  # ???
-
     spam_aliases: int = 0  # ???
     pushover_active: bool = False  # Push notification settings
     percent_class: str = "success"  # ??? E.g. 'success'
@@ -115,6 +128,18 @@ class MailcowMailbox(MailcowAPIResponse):
     attributes: MailboxAttributes = field(default_factory=MailboxAttributes)
     custom_attributes: Dict[str, str] = field(default_factory=dict)
     tags: List[str] = field(default_factory=list)
+
+    _cleanable_bools = ("rl", "is_relayed", "pushover_active")
+    _cleanable_strings = ("local_part", "domain", "rl_scope", "percent_class")
+    _cleanable_ints = (
+        "active_int",
+        "messages",
+        "quota",
+        "quota_used",
+        "max_new_quota",
+        "spam_aliases",
+    )
+    _cleanable_datetimes = ("created", "modified", "last_imap_login", "last_smtp_login", "last_pop3_login")
 
     def __post_init__(self):
         index = self.username.find("@")
@@ -128,26 +153,57 @@ class MailcowMailbox(MailcowAPIResponse):
             self.active_int = self.active.value
 
     @classmethod
-    def from_json(cls, json: dict) -> "MailcowMailbox":
-        json.update(
-            {
-                "active": MailboxStatus(json["active"]),
-                "created": datetime.fromisoformat(json["created"]),
-                "modified": datetime.fromisoformat(json["modified"]) if json["modified"] is not None else None,
-                "percent_in_use": int(json["percent_in_use"]) if json["percent_in_use"] != "- " else None,
-                "rl": bool(json["rl"]),
-                "is_relayed": bool(json["is_relayed"]),
-                "last_imap_login": (
-                    datetime.fromtimestamp(int(json["last_imap_login"])) if json["last_imap_login"] != "0" else None
-                ),
-                "last_smtp_login": (
-                    datetime.fromtimestamp(int(json["last_smtp_login"])) if json["last_smtp_login"] != "0" else None
-                ),
-                "last_pop3_login": (
-                    datetime.fromtimestamp(int(json["last_pop3_login"])) if json["last_pop3_login"] != "0" else None
-                ),
-                "pushover_active": bool(json["pushover_active"]),
-                "attributes": MailboxAttributes.from_json_safe(json["attributes"]) or MailboxAttributes(),
-            }
-        )
-        return cls(**json)
+    def clean(cls, json: dict, extra_keys: Set[str] = None):
+        username = json.get("username", None)
+        name = json.get("name", None)
+        if username is None:
+            cls._issue_warning("username", username)
+            raise AttributeError(f"username was not provided when creating {cls.__name__}")
+        if name is None:
+            cls._issue_warning("name", name)
+            raise AttributeError(f"name was not provided when creating {cls.__name__}")
+
+        # Validate custom attributes
+        custom_attributes = json.get("custom_attributes", None)
+        if isinstance(custom_attributes, dict):
+            custom_attributes = {str(k): str(v) for k, v in custom_attributes.items()}
+        else:
+            if not isinstance(custom_attributes, list) or custom_attributes:
+                # If no custom_attributes are set, the API returns it as []
+                cls._issue_warning("custom_attributes", custom_attributes, "dict")
+            custom_attributes = {}
+
+        # Validate tags
+        tags = json.get("tags", [])
+        if isinstance(tags, list):
+            tags = [str(tag) for tag in tags]
+        else:
+            cls._issue_warning("tags", tags, "list")
+            tags = []
+
+        new_json = {
+            "username": username,
+            "name": name,
+            "attributes": MailboxAttributes.from_json(json.get("attributes", {})) or MailboxAttributes(),
+            "custom_attributes": custom_attributes,
+            "tags": tags,
+        }
+
+        # Active-status
+        active = cls._parse_as_enum("active", json, MailboxStatus)
+        if active is not None:
+            new_json["active"] = active
+
+        # Mailbox percentage is a number, or "- " if unlimited
+        percent = json.get("percent_in_use")
+        if percent == "- ":
+            new_json["percent_in_use"] = None
+        elif not isinstance(percent, int):
+            cls._issue_warning("percent_in_use", percent, "int (or '- ')")
+        else:
+            new_json["percent_in_use"] = percent
+
+        extra_keys = extra_keys or set()
+        new_json.update(**super().clean(json, extra_keys=new_json.keys() | extra_keys))
+
+        return new_json

--- a/mailcow_integration/api/interface/rspamd.py
+++ b/mailcow_integration/api/interface/rspamd.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Set
 
 from mailcow_integration.api.interface.base import MailcowAPIResponse
 
@@ -13,7 +13,6 @@ class RspamdSettings(MailcowAPIResponse):
     content: str  # rspamd configuration
     active: bool = True
 
-    @classmethod
-    def from_json(cls, json: dict) -> "RspamdSettings":
-        json.update({"active": bool(json["active"])})
-        return cls(**json)
+    _cleanable_bools = ("active",)
+    _cleanable_ints = ("id",)
+    _cleanable_strings = ("desc", "content")

--- a/mailcow_integration/management/commands/mailcow_api_request.py
+++ b/mailcow_integration/management/commands/mailcow_api_request.py
@@ -11,10 +11,13 @@ class Command(BaseCommand):  # pragma: no cover
         parser.add_argument("endpoint", type=str)
 
     def handle(self, *args, **options):
-        # NOTE: The Mailcow API uses an IP whitelist. Make sure to add your local IP to this list in the admin panel.
+        # NOTE: The Mailcow API uses an IP whitelist. Make sure to add your local IP to this list in the Mailcow admin panel.
+        assert settings.MAILCOW_HOST is not None, "Mailcow host should be set in the settings"
+        assert settings.MAILCOW_API_KEY is not None, "Mailcow API key should be set in the settings"
         client = MailcowAPIClient(settings.MAILCOW_HOST, settings.MAILCOW_API_KEY)
 
         res = client._make_request(options["endpoint"])
 
         self.stdout.write(self.style.SUCCESS(res))
-        self.stdout.write(self.style.SUCCESS(res.content))
+        if not isinstance(res, list):
+            self.stdout.write(self.style.SUCCESS(res.content))

--- a/mailcow_integration/squire_mailcow.py
+++ b/mailcow_integration/squire_mailcow.py
@@ -131,6 +131,8 @@ class SquireMailcowManager:
         # Fetch all Rspamd settings
         settings = self._client.get_rspamd_setting_all()
         for setting in settings:
+            if setting is None:
+                continue
             # Setting description matches the one we normally set
             if setting.desc == self.INTERNAL_ALIAS_SETTING_NAME % self.INTERNAL_ALIAS_SETTING_WHITELIST_NAME:
                 self._internal_rspamd_setting_whitelist = setting
@@ -206,7 +208,7 @@ class SquireMailcowManager:
         """Gets all email aliases"""
         if use_cache and self._alias_cache is not None:
             return self._alias_cache
-        self._alias_cache = list(self._client.get_alias_all())
+        self._alias_cache = [a for a in self._client.get_alias_all() if a is not None]
         self._alias_map_cache = None
         return self._alias_cache
 
@@ -214,7 +216,7 @@ class SquireMailcowManager:
         """Gets all mailboxes"""
         if use_cache and self._mailbox_cache is not None:
             return self._mailbox_cache
-        self._mailbox_cache = list(self._client.get_mailbox_all())
+        self._mailbox_cache = [m for m in self._client.get_mailbox_all() if m is not None]
         self._mailbox_map_cache = None
         return self._mailbox_cache
 

--- a/mailcow_integration/tests/api/test_interfaces.py
+++ b/mailcow_integration/tests/api/test_interfaces.py
@@ -44,16 +44,17 @@ def get_mailbox_json():
             "rl_scope": "domain",
             "is_relayed": 0,
             "name": "Mr. Foo",
-            "last_imap_login": "1665675411",
-            "last_smtp_login": "0",
-            "last_pop3_login": "0",
+            "last_imap_login": 1665675411,
+            "last_smtp_login": 0,
+            "last_pop3_login": 0,
             "active": 1,
             "active_int": 1,
             "domain": "example.com",
-            "domain_xmpp": 0,
-            "domain_xmpp_prefix": "im",
             "local_part": "foo",
             "quota": 1048576,
+            "created": "2021-08-31 19:04:24",
+            "modified": "2022-08-31 19:04:24",
+            "custom_attributes": [],
             "attributes": {
                 "force_pw_update": "0",
                 "tls_enforce_in": "0",
@@ -67,6 +68,9 @@ def get_mailbox_json():
                 "pop3_access": "1",
                 "smtp_access": "1",
                 "quarantine_category": "reject",
+                "relayhost": True,
+                "sieve_access": True,
+                "passwd_update": "2024-09-14 17:13:08",
             },
             "quota_used": 94129,
             "percent_in_use": 9,
@@ -124,6 +128,9 @@ class MailcowInterfacesTest(TestCase):
         self.assertIsNone(mailbox.last_smtp_login)
         self.assertIsNone(mailbox.last_pop3_login)
         self.assertEqual(mailbox.pushover_active, False)
+        self.assertEqual(mailbox.created, datetime.fromisoformat("2021-08-31 19:04:24"))
+        self.assertEqual(mailbox.modified, datetime.fromisoformat("2022-08-31 19:04:24"))
+        self.assertDictEqual(mailbox.custom_attributes, {})
 
         # Mailbox attributes
         self.assertEqual(mailbox.attributes.force_pw_update, False)
@@ -137,6 +144,9 @@ class MailcowInterfacesTest(TestCase):
         self.assertEqual(mailbox.attributes.xmpp_admin, False)
         self.assertEqual(mailbox.attributes.quarantine_notification, QuarantineNotification.NEVER)
         self.assertEqual(mailbox.attributes.quarantine_category, QuarantaineNotificationCategory.REJECT)
+        self.assertEqual(mailbox.attributes.relayhost, True)
+        self.assertEqual(mailbox.attributes.sieve_access, True)
+        self.assertEqual(mailbox.attributes.passwd_update, datetime.fromisoformat("2024-09-14 17:13:08"))
 
         # No quota
         data["percent_in_use"] = "- "

--- a/squire/settings.py
+++ b/squire/settings.py
@@ -197,7 +197,7 @@ LOCALE_PATHS = [
 ]
 
 # Log Settings
-APPLICATION_LOG_LEVEL = "INFO"
+APPLICATION_LOG_LEVEL = "INFO" if DEBUG else "ERROR"
 
 LOGGING = {
     "version": 1,
@@ -207,11 +207,21 @@ LOGGING = {
             # exact format is not important, this is the minimum information
             "format": "%(asctime)s (%(name)-12s) [%(levelname)s] %(message)s",
         },
+        "file": {
+            "format": "%(asctime)s (%(name)s) [%(levelname)s] %(message)s",
+        },
     },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
             "formatter": "console",
+        },
+        "logfile": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": os.path.join(BASE_DIR, "squire", "logs", "squire.log"),
+            "maxBytes": 1024 * 1024 * 5,  # 5MB
+            "backupCount": 1,  # Keep 1 historical versions
+            "formatter": "file",
         },
     },
     "loggers": {
@@ -242,6 +252,10 @@ LOGGING = {
         "mailcow_integration": {
             "handlers": ["console"],
             "level": APPLICATION_LOG_LEVEL,
+        },
+        "mailcow_api": {
+            "handlers": ["console", "logfile"],
+            "level": "WARNING",
         },
     },
 }

--- a/squire/settings.py
+++ b/squire/settings.py
@@ -393,7 +393,7 @@ MARKDOWN_IMAGE_MODELS = (
     "roleplaying.roleplayingsystem",
 )
 
-# Maror static overrides
+# Martor static overrides
 MARTOR_ALTERNATIVE_JS_FILE_THEME = None
 MARTOR_ALTERNATIVE_CSS_FILE_THEME = "theming/martor-admin-bootstrap.css"  # default None
 MARTOR_ALTERNATIVE_JQUERY_JS_FILE = None
@@ -419,6 +419,9 @@ SERVER_EMAIL = f"{APPLICATION_NAME} Error <{APPLICATION_NAME.lower()}-error@kotk
 
 # Default email address to use for various automated correspondence from the site manager(s).
 DEFAULT_FROM_EMAIL = f"{APPLICATION_NAME} <{APPLICATION_NAME.lower()}-noreply@kotkt.nl>"
+
+# Ensure logs directory exists
+os.makedirs(os.path.join(BASE_DIR, "squire", "logs"), exist_ok=True)
 
 # Debug settings
 # Also run the following command to imitate an SMTP server locally: python -m smtpd -n -c DebuggingServer localhost:1025


### PR DESCRIPTION
Mailcow's API was changed in one of the recent updates that we applied to our installation. This changes the way Squire handles the API:

- More robust: Squire will no longer crash when the MailCow API returns an unexpected item, or does not return an expected item. This won't prevent Squire from crashing from breaking API-changes, but will prevent issues like the one we've seen in this Mailcow update.
- API and Squire-dataclass mismatches are reported in `squire/logs/squire.log`. This log can be viewed from the server status tabs. Warnings are written to this file when:
  - Additional fields are returned by the MailCow API, but were not expected when Squire
  - Fields are expected by Squire('s dataclass), but not returned by the Mailcow API
  - A field value returned by the Mailcow API cannot be parsed in the expected format (e.g. Squire expects a boolean but '3' was returned)
- The logfile is highlighted when viewed in Squire

<details><summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/07f46d27-0f1d-487e-96bf-c185a554e224)
</details>