### PR TITLE
Update AssociationGroupsTabAccessForm to use ModelForm

### DIFF
--- a/committees/admin/forms.py
+++ b/committees/admin/forms.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import Permission
-from django.forms import Form
+from django.forms import ModelForm
 from django.forms.fields import BooleanField
 from django.forms.widgets import Input
 
@@ -35,8 +35,12 @@ class ConfigTabSelectWidget(Input):
         return False
 
 
-class AssociationGroupsTabAccessForm(Form):
+class AssociationGroupsTabAccessForm(ModelForm):
     """Form that allows changing of tab access for the given AssociationGroupPanelControl instance"""
+
+    class Meta:
+        model = AssociationGroupPanelControl
+        fields = []
 
     def __init__(self, *args, instance: AssociationGroupPanelControl = None, **kwargs):
         super(AssociationGroupsTabAccessForm, self).__init__(*args, **kwargs)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,7 +2,7 @@
 # These are libraries that are needed for any environment
 
 # Import the common-dependencies
-Django~=4.2.16
+Django~=4.2.25
 django-bootstrap4~=24.4
 django-cleanup~=9.0.0 # Removes old FileField files upon saving
 djangorestframework~=3.15.1 # TODO: Deprecate


### PR DESCRIPTION
Context by Wouter:
> The UUPS new member group, which [person] is part of, poses one new situation that we haven't had before. What if someone can view the page, but does not have rights to edit everything. The Django Admin is very simple in that aspect. We render everything as is, but on the linked Form (normally a ModelForm) we set every field in the Forms' readonly_fields property instead. During the render process, the admin notices the readonly fields and try to render them as such - by the way, the 'default' values that we as superusers can see are rendered through a different pipeline as in that case it's a special field instances that knows it is default and thus renders the disabled state - anyhow, read only fields in the admin are rendered through the AdminReadonlyField class and that is where _meta is called. But... it's not a ModelForm so fails
> 
> I'm not in a position to test the code today, but I think if you adjust the AssociationGroupsTabAccessForm to the following code it should be fixed.

I have tested it and it does work.
